### PR TITLE
implement alternative fill rules for shapes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,6 @@
   <!-- Default settings that explicitly differ from the Sdk.props defaults  -->
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <BaseIntermediateOutputPath>$(BaseArtifactsPath)obj/$(BaseArtifactsPathSuffix)/</BaseIntermediateOutputPath>
     <DebugType>portable</DebugType>
     <DebugType Condition="'$(codecov)' != ''">full</DebugType>
     <NullableContextOptions>disable</NullableContextOptions>
@@ -66,7 +65,6 @@
   <!-- Default settings that explicitly differ from the Sdk.targets defaults-->
   <PropertyGroup>
     <Authors>Six Labors and contributors</Authors>
-    <BaseOutputPath>$(BaseArtifactsPath)bin/$(BaseArtifactsPathSuffix)/</BaseOutputPath>
     <Company>Six Labors</Company>
     <PackageOutputPath>$(BaseArtifactsPath)pkg/$(BaseArtifactsPathSuffix)/$(Configuration)/</PackageOutputPath>
     <Product>SixLabors.ImageSharp.Drawing</Product>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,5 +2,6 @@ continuous-delivery-fallback-tag: ci
 branches:
     master:
         tag: unstable
+        mode: ContinuousDeployment
     pull-request:
         tag: pr

--- a/ci-test.ps1
+++ b/ci-test.ps1
@@ -35,7 +35,3 @@ else {
 
   dotnet test --no-build -c Release -f $targetFramework
 }
-
-# Explicitly exit with 0 to ignore errors caused by coverlet attempting to read
-# project files that dotnet test is set to ignore.
-exit 0

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -50,6 +50,6 @@
 
   <!-- Empty target so that `dotnet test` will work on the solution -->
   <!-- https://github.com/Microsoft/vstest/issues/411 -->
-  <Target Name="VSTest" />
+  <Target Name="VSTest" Condition="'$(IsTestProject)' == 'true'"/>
 
 </Project>

--- a/src/ImageSharp.Drawing/Primitives/Region.cs
+++ b/src/ImageSharp.Drawing/Primitives/Region.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
 using SixLabors.Primitives;
+using SixLabors.Shapes;
 
 namespace SixLabors.ImageSharp.Primitives
 {
@@ -30,7 +31,8 @@ namespace SixLabors.ImageSharp.Primitives
         /// <param name="y">The position along the y axis to find intersections.</param>
         /// <param name="buffer">The buffer.</param>
         /// <param name="configuration">A <see cref="Configuration"/> instance in the context of the caller.</param>
+        /// <param name="intersectionRule">How intersections are handled.</param>
         /// <returns>The number of intersections found.</returns>
-        public abstract int Scan(float y, Span<float> buffer, Configuration configuration);
+        public abstract int Scan(float y, Span<float> buffer, Configuration configuration, IntersectionRule intersectionRule);
     }
 }

--- a/src/ImageSharp.Drawing/Primitives/ShapeRegion.cs
+++ b/src/ImageSharp.Drawing/Primitives/ShapeRegion.cs
@@ -42,7 +42,7 @@ namespace SixLabors.ImageSharp.Primitives
         public override Rectangle Bounds { get; }
 
         /// <inheritdoc/>
-        public override int Scan(float y, Span<float> buffer, Configuration configuration)
+        public override int Scan(float y, Span<float> buffer, Configuration configuration, IntersectionRule intersectionRule)
         {
             var start = new PointF(this.Bounds.Left - 1, y);
             var end = new PointF(this.Bounds.Right + 1, y);
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Primitives
             using (IMemoryOwner<PointF> tempBuffer = configuration.MemoryAllocator.Allocate<PointF>(buffer.Length))
             {
                 Span<PointF> innerBuffer = tempBuffer.Memory.Span;
-                int count = this.Shape.FindIntersections(start, end, innerBuffer);
+                int count = this.Shape.FindIntersections(start, end, innerBuffer, intersectionRule);
 
                 for (int i = 0; i < count; i++)
                 {

--- a/src/ImageSharp.Drawing/Processing/Extensions/DrawBezierExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/DrawBezierExtensions.cs
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext DrawBeziers(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             float thickness,
             params PointF[] points) =>
@@ -69,7 +69,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext DrawBeziers(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             float thickness,
             params PointF[] points) =>
@@ -85,7 +85,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext DrawBeziers(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IPen pen,
             params PointF[] points) =>
             source.Draw(options, pen, new Path(new CubicBezierLineSegment(points)));

--- a/src/ImageSharp.Drawing/Processing/Extensions/DrawLineExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/DrawLineExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.Primitives;
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext DrawLines(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             float thickness,
             params PointF[] points) =>
@@ -69,7 +69,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>>
         public static IImageProcessingContext DrawLines(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             float thickness,
             params PointF[] points) =>
@@ -85,7 +85,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext DrawLines(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IPen pen,
             params PointF[] points) =>
             source.Draw(options, pen, new Path(new LinearLineSegment(points)));

--- a/src/ImageSharp.Drawing/Processing/Extensions/DrawPathCollectionExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/DrawPathCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.Shapes;
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Draw(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IPen pen,
             IPathCollection paths)
         {
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext
             Draw(this IImageProcessingContext source, IPen pen, IPathCollection paths) =>
-            source.Draw(new GraphicsOptions(), pen, paths);
+            source.Draw(new ShapeGraphicsOptions(), pen, paths);
 
         /// <summary>
         /// Draws the outline of the polygon with the provided brush at the provided thickness.
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Draw(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             float thickness,
             IPathCollection paths) =>
@@ -86,7 +86,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Draw(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             float thickness,
             IPathCollection paths) =>

--- a/src/ImageSharp.Drawing/Processing/Extensions/DrawPathExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/DrawPathExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Primitives;
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Draw(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IPen pen,
             IPath path) =>
             source.Fill(options, pen.StrokeFill, new ShapePath(path, pen));
@@ -34,7 +34,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="path">The path.</param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Draw(this IImageProcessingContext source, IPen pen, IPath path) =>
-            source.Draw(new GraphicsOptions(), pen, path);
+            source.Draw(new ShapeGraphicsOptions(), pen, path);
 
         /// <summary>
         /// Draws the outline of the polygon with the provided brush at the provided thickness.
@@ -47,7 +47,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Draw(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             float thickness,
             IPath path) =>
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Draw(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             float thickness,
             IPath path) =>

--- a/src/ImageSharp.Drawing/Processing/Extensions/DrawPolygonExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/DrawPolygonExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.Primitives;
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext DrawPolygon(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             float thickness,
             params PointF[] points) =>
@@ -69,7 +69,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext DrawPolygon(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             float thickness,
             params PointF[] points) =>
@@ -86,7 +86,7 @@ namespace SixLabors.ImageSharp.Processing
             this IImageProcessingContext source,
             IPen pen,
             params PointF[] points) =>
-            source.Draw(new GraphicsOptions(), pen, new Polygon(new LinearLineSegment(points)));
+            source.Draw(new ShapeGraphicsOptions(), pen, new Polygon(new LinearLineSegment(points)));
 
         /// <summary>
         /// Draws the provided Points as a closed Linear Polygon with the provided Pen.
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext DrawPolygon(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IPen pen,
             params PointF[] points) =>
             source.Draw(options, pen, new Polygon(new LinearLineSegment(points)));

--- a/src/ImageSharp.Drawing/Processing/Extensions/DrawRectangleExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/DrawRectangleExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.Primitives;
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Draw(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IPen pen,
             RectangleF shape) =>
             source.Draw(options, pen, new RectangularPolygon(shape.X, shape.Y, shape.Width, shape.Height));
@@ -34,7 +34,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="shape">The shape.</param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Draw(this IImageProcessingContext source, IPen pen, RectangleF shape) =>
-            source.Draw(new GraphicsOptions(), pen, shape);
+            source.Draw(new ShapeGraphicsOptions(), pen, shape);
 
         /// <summary>
         /// Draws the outline of the rectangle with the provided brush at the provided thickness.
@@ -47,7 +47,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Draw(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             float thickness,
             RectangleF shape) =>
@@ -79,7 +79,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Draw(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             float thickness,
             RectangleF shape) =>

--- a/src/ImageSharp.Drawing/Processing/Extensions/FillPathBuilderExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/FillPathBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -22,7 +22,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             Action<PathBuilder> path)
         {
@@ -43,7 +43,7 @@ namespace SixLabors.ImageSharp.Processing
             this IImageProcessingContext source,
             IBrush brush,
             Action<PathBuilder> path) =>
-            source.Fill(new GraphicsOptions(), brush, path);
+            source.Fill(new ShapeGraphicsOptions(), brush, path);
 
         /// <summary>
         /// Flood fills the image in the shape of the provided polygon with the specified brush.
@@ -55,7 +55,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             Action<PathBuilder> path) =>
             source.Fill(options, new SolidBrush(color), path);

--- a/src/ImageSharp.Drawing/Processing/Extensions/FillPathCollectionExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/FillPathCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.Shapes;
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             IPathCollection paths)
         {
@@ -43,7 +43,7 @@ namespace SixLabors.ImageSharp.Processing
             this IImageProcessingContext source,
             IBrush brush,
             IPathCollection paths) =>
-            source.Fill(new GraphicsOptions(), brush, paths);
+            source.Fill(new ShapeGraphicsOptions(), brush, paths);
 
         /// <summary>
         /// Flood fills the image in the shape of the provided polygon with the specified brush.
@@ -55,7 +55,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             IPathCollection paths) =>
             source.Fill(options, new SolidBrush(color), paths);

--- a/src/ImageSharp.Drawing/Processing/Extensions/FillPathExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/FillPathExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.ImageSharp.Primitives;
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             IPath path) =>
             source.Fill(options, brush, new ShapeRegion(path));
@@ -34,7 +34,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="path">The path.</param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(this IImageProcessingContext source, IBrush brush, IPath path) =>
-            source.Fill(new GraphicsOptions(), brush, new ShapeRegion(path));
+            source.Fill(new ShapeGraphicsOptions(), brush, new ShapeRegion(path));
 
         /// <summary>
         /// Flood fills the image in the shape of the provided polygon with the specified brush..
@@ -46,7 +46,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             IPath path) =>
             source.Fill(options, new SolidBrush(color), path);

--- a/src/ImageSharp.Drawing/Processing/Extensions/FillPolygonExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/FillPolygonExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.Primitives;
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext FillPolygon(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             params PointF[] points) =>
             source.Fill(options, brush, new Polygon(new LinearLineSegment(points)));
@@ -49,7 +49,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext FillPolygon(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             params PointF[] points) =>
             source.Fill(options, new SolidBrush(color), new Polygon(new LinearLineSegment(points)));

--- a/src/ImageSharp.Drawing/Processing/Extensions/FillRectangleExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/FillRectangleExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using SixLabors.Primitives;
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             RectangleF shape) =>
             source.Fill(options, brush, new RectangularPolygon(shape.X, shape.Y, shape.Width, shape.Height));
@@ -47,7 +47,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             RectangleF shape) =>
             source.Fill(options, new SolidBrush(color), shape);

--- a/src/ImageSharp.Drawing/Processing/Extensions/FillRegionExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/FillRegionExtensions.cs
@@ -37,7 +37,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <param name="region">The region.</param>
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(this IImageProcessingContext source, IBrush brush, Region region) =>
-            source.Fill(new GraphicsOptions(), brush, region);
+            source.Fill(new ShapeGraphicsOptions(), brush, region);
 
         /// <summary>
         /// Flood fills the image with in the region with the specified color.
@@ -49,7 +49,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             Color color,
             Region region) =>
             source.Fill(options, new SolidBrush(color), region);
@@ -74,7 +74,7 @@ namespace SixLabors.ImageSharp.Processing
         /// <returns>The <see cref="Image{TPixel}"/>.</returns>
         public static IImageProcessingContext Fill(
             this IImageProcessingContext source,
-            GraphicsOptions options,
+            ShapeGraphicsOptions options,
             IBrush brush,
             Region region) =>
             source.ApplyProcessor(new FillRegionProcessor(options, brush, region));

--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor.cs
@@ -19,11 +19,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
         /// <param name="options">The graphics options.</param>
         /// <param name="brush">The details how to fill the region of interest.</param>
         /// <param name="region">The region of interest to be filled.</param>
-        public FillRegionProcessor(GraphicsOptions options, IBrush brush, Region region)
+        public FillRegionProcessor(ShapeGraphicsOptions options, IBrush brush, Region region)
         {
             this.Region = region;
             this.Brush = brush;
-            this.Options = options;
+            this.ShapeOptions = options;
+            this.Options = (GraphicsOptions)options;
         }
 
         /// <summary>
@@ -35,6 +36,11 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
         /// Gets the region that this processor applies to.
         /// </summary>
         public Region Region { get; }
+
+        /// <summary>
+        /// Gets the <see cref="GraphicsOptions"/> defining how to blend the brush pixels over the image pixels.
+        /// </summary>
+        public ShapeGraphicsOptions ShapeOptions { get; }
 
         /// <summary>
         /// Gets the <see cref="GraphicsOptions"/> defining how to blend the brush pixels over the image pixels.

--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillRegionProcessor{TPixel}.cs
@@ -34,6 +34,7 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
         {
             Configuration configuration = this.Configuration;
             GraphicsOptions options = this.definition.Options;
+            ShapeGraphicsOptions shapeOptions = this.definition.ShapeOptions;
             IBrush brush = this.definition.Brush;
             Region region = this.definition.Region;
             Rectangle rect = region.Bounds;
@@ -98,14 +99,12 @@ namespace SixLabors.ImageSharp.Processing.Processors.Drawing
                         float yPlusOne = y + 1;
                         for (float subPixel = y; subPixel < yPlusOne; subPixel += subpixelFraction)
                         {
-                            int pointsFound = region.Scan(subPixel + offset, buffer, configuration);
+                            int pointsFound = region.Scan(subPixel + offset, buffer, configuration, shapeOptions.IntersectionRule);
                             if (pointsFound == 0)
                             {
                                 // nothing on this line, skip
                                 continue;
                             }
-
-                            QuickSort.Sort(buffer.Slice(0, pointsFound));
 
                             for (int point = 0; point < pointsFound && point < buffer.Length - 1; point += 2)
                             {

--- a/src/ImageSharp.Drawing/Processing/ShapeGraphicsOptions.cs
+++ b/src/ImageSharp.Drawing/Processing/ShapeGraphicsOptions.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.Fonts;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.Shapes;
+
+namespace SixLabors.ImageSharp.Processing
+{
+    /// <summary>
+    /// Options for influencing the drawing functions.
+    /// </summary>
+    public class ShapeGraphicsOptions : IDeepCloneable<ShapeGraphicsOptions>
+    {
+        private int antialiasSubpixelDepth = 16;
+        private float blendPercentage = 1F;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShapeGraphicsOptions"/> class.
+        /// </summary>
+        public ShapeGraphicsOptions()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ShapeGraphicsOptions"/> class.
+        /// </summary>
+        /// <param name="source">The source to clone from.</param>
+        public ShapeGraphicsOptions(GraphicsOptions source)
+        {
+            this.AlphaCompositionMode = source.AlphaCompositionMode;
+            this.Antialias = source.Antialias;
+            this.AntialiasSubpixelDepth = source.AntialiasSubpixelDepth;
+            this.BlendPercentage = source.BlendPercentage;
+            this.ColorBlendingMode = source.ColorBlendingMode;
+        }
+
+        private ShapeGraphicsOptions(ShapeGraphicsOptions source)
+        {
+            this.AlphaCompositionMode = source.AlphaCompositionMode;
+            this.Antialias = source.Antialias;
+            this.AntialiasSubpixelDepth = source.AntialiasSubpixelDepth;
+            this.BlendPercentage = source.BlendPercentage;
+            this.ColorBlendingMode = source.ColorBlendingMode;
+            this.IntersectionRule = source.IntersectionRule;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether antialiasing should be applied.
+        /// Defaults to true.
+        /// </summary>
+        public IntersectionRule IntersectionRule { get; set; } = IntersectionRule.OddEven;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether antialiasing should be applied.
+        /// Defaults to true.
+        /// </summary>
+        public bool Antialias { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating the number of subpixels to use while rendering with antialiasing enabled.
+        /// </summary>
+        public int AntialiasSubpixelDepth
+        {
+            get
+            {
+                return this.antialiasSubpixelDepth;
+            }
+
+            set
+            {
+                Guard.MustBeGreaterThanOrEqualTo(value, 0, nameof(this.AntialiasSubpixelDepth));
+                this.antialiasSubpixelDepth = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating the blending percentage to apply to the drawing operation.
+        /// </summary>
+        public float BlendPercentage
+        {
+            get
+            {
+                return this.blendPercentage;
+            }
+
+            set
+            {
+                Guard.MustBeBetweenOrEqualTo(value, 0, 1F, nameof(this.BlendPercentage));
+                this.blendPercentage = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating the color blending percentage to apply to the drawing operation.
+        /// Defaults to <see cref= "PixelColorBlendingMode.Normal" />.
+        /// </summary>
+        public PixelColorBlendingMode ColorBlendingMode { get; set; } = PixelColorBlendingMode.Normal;
+
+        /// <summary>
+        /// Gets or sets a value indicating the color blending percentage to apply to the drawing operation
+        /// Defaults to <see cref= "PixelAlphaCompositionMode.SrcOver" />.
+        /// </summary>
+        public PixelAlphaCompositionMode AlphaCompositionMode { get; set; } = PixelAlphaCompositionMode.SrcOver;
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="GraphicsOptions"/> to <see cref="TextGraphicsOptions"/>.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        public static implicit operator ShapeGraphicsOptions(GraphicsOptions options)
+        {
+            return new ShapeGraphicsOptions(options);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="TextGraphicsOptions"/> to <see cref="GraphicsOptions"/>.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <returns>
+        /// The result of the conversion.
+        /// </returns>
+        public static explicit operator GraphicsOptions(ShapeGraphicsOptions options)
+        {
+            return new GraphicsOptions()
+            {
+                Antialias = options.Antialias,
+                AntialiasSubpixelDepth = options.AntialiasSubpixelDepth,
+                ColorBlendingMode = options.ColorBlendingMode,
+                AlphaCompositionMode = options.AlphaCompositionMode,
+                BlendPercentage = options.BlendPercentage
+            };
+        }
+
+        /// <inheritdoc/>
+        public ShapeGraphicsOptions DeepClone() => new ShapeGraphicsOptions(this);
+    }
+}

--- a/src/ImageSharp.Drawing/Shapes/EllipsePolygon.cs
+++ b/src/ImageSharp.Drawing/Shapes/EllipsePolygon.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -145,16 +145,29 @@ namespace SixLabors.Shapes
         }
 
         /// <inheritdoc/>
+        int IPath.FindIntersections(PointF start, PointF end, PointF[] buffer, int offset, IntersectionRule intersectionRule)
+        {
+            Span<PointF> subBuffer = buffer.AsSpan(offset);
+            return this.innerPath.FindIntersections(start, end, subBuffer, intersectionRule);
+        }
+
+        /// <inheritdoc/>
+        int IPath.FindIntersections(PointF start, PointF end, Span<PointF> buffer, IntersectionRule intersectionRule)
+        {
+            return this.innerPath.FindIntersections(start, end, buffer, intersectionRule);
+        }
+
+        /// <inheritdoc/>
         int IPath.FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
         {
             Span<PointF> subBuffer = buffer.AsSpan(offset);
-            return this.innerPath.FindIntersections(start, end, subBuffer);
+            return this.innerPath.FindIntersections(start, end, subBuffer, IntersectionRule.OddEven);
         }
 
         /// <inheritdoc/>
         int IPath.FindIntersections(PointF start, PointF end, Span<PointF> buffer)
         {
-            return this.innerPath.FindIntersections(start, end, buffer);
+            return this.innerPath.FindIntersections(start, end, buffer, IntersectionRule.OddEven);
         }
 
         /// <summary>

--- a/src/ImageSharp.Drawing/Shapes/IPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/IPath.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -81,6 +81,33 @@ namespace SixLabors.Shapes
         /// The number of intersections populated into the buffer.
         /// </returns>
         int FindIntersections(PointF start, PointF end, Span<PointF> buffer);
+
+        /// <summary>
+        /// Based on a line described by <paramref name="start"/> and <paramref name="end"/>
+        /// populate a buffer for all points on the polygon that the line intersects.
+        /// </summary>
+        /// <param name="start">The start point of the line.</param>
+        /// <param name="end">The end point of the line.</param>
+        /// <param name="buffer">The buffer that will be populated with intersections.</param>
+        /// <param name="offset">The offset within the buffer to start.</param>
+        /// <param name="intersectionRule">How intersections are handled</param>
+        /// <returns>
+        /// The number of intersections populated into the buffer.
+        /// </returns>
+        int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset, IntersectionRule intersectionRule);
+
+        /// <summary>
+        /// Based on a line described by <paramref name="start"/> and <paramref name="end"/>
+        /// populate a buffer for all points on the polygon that the line intersects.
+        /// </summary>
+        /// <param name="start">The start point of the line.</param>
+        /// <param name="end">The end point of the line.</param>
+        /// <param name="buffer">The buffer that will be populated with intersections.</param>
+        /// <param name="intersectionRule">How intersections are handled</param>
+        /// <returns>
+        /// The number of intersections populated into the buffer.
+        /// </returns>
+        int FindIntersections(PointF start, PointF end, Span<PointF> buffer, IntersectionRule intersectionRule);
 
         /// <summary>
         /// Determines whether the <see cref="IPath"/> contains the specified point

--- a/src/ImageSharp.Drawing/Shapes/InternalPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/InternalPath.cs
@@ -727,7 +727,7 @@ namespace SixLabors.Shapes
 
             if (isClosed)
             {
-                //walk back removing collinear points
+                // walk back removing collinear points
                 while (results.Count > 2 && results.Last().Orientation == Orientation.Colinear)
                 {
                     results.RemoveAt(results.Count - 1);

--- a/src/ImageSharp.Drawing/Shapes/InternalPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/InternalPath.cs
@@ -178,6 +178,18 @@ namespace SixLabors.Shapes
         /// <param name="buffer">The buffer.</param>
         /// <returns>number of intersections hit</returns>
         public int FindIntersections(PointF start, PointF end, Span<PointF> buffer)
+            => this.FindIntersections(start, end, buffer, IntersectionRule.OddEven);
+
+        /// <summary>
+        /// Based on a line described by <paramref name="start" /> and <paramref name="end" />
+        /// populates a buffer for all points on the path that the line intersects.
+        /// </summary>
+        /// <param name="start">The start.</param>
+        /// <param name="end">The end.</param>
+        /// <param name="buffer">The buffer.</param>
+        /// <param name="intersectionRule">Intersection rule types</param>
+        /// <returns>number of intersections hit</returns>
+        public int FindIntersections(PointF start, PointF end, Span<PointF> buffer, IntersectionRule intersectionRule)
         {
             if (this.points.Length < 2)
             {

--- a/src/ImageSharp.Drawing/Shapes/InternalPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/InternalPath.cs
@@ -727,11 +727,11 @@ namespace SixLabors.Shapes
 
             if (isClosed)
             {
-                // walk back removing collinear points
-                //while (results.Count > 2 && results.Last().Orientation == Orientation.Colinear)
-                //{
-                //    results.RemoveAt(results.Count - 1);
-                //}
+                //walk back removing collinear points
+                while (results.Count > 2 && results.Last().Orientation == Orientation.Colinear)
+                {
+                    results.RemoveAt(results.Count - 1);
+                }
             }
 
             PointData[] data = results.ToArray();

--- a/src/ImageSharp.Drawing/Shapes/IntersectionRule.cs
+++ b/src/ImageSharp.Drawing/Shapes/IntersectionRule.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+namespace SixLabors.Shapes
+{
+    /// <summary>
+    /// Rule for calulating intersection points,
+    /// </summary>
+    public enum IntersectionRule
+    {
+        /// <summary>
+        /// Use odd/even intersection rules, self intersection will cause holes.
+        /// </summary>
+        OddEven,
+
+        /// <summary>
+        /// Nonzero rule treats intersecting holes as inside the path thus being ignored by intersections.
+        /// </summary>
+        Nonzero
+    }
+}

--- a/src/ImageSharp.Drawing/Shapes/IntersectionRule.cs
+++ b/src/ImageSharp.Drawing/Shapes/IntersectionRule.cs
@@ -11,11 +11,11 @@ namespace SixLabors.Shapes
         /// <summary>
         /// Use odd/even intersection rules, self intersection will cause holes.
         /// </summary>
-        OddEven,
+        OddEven = 0,
 
         /// <summary>
         /// Nonzero rule treats intersecting holes as inside the path thus being ignored by intersections.
         /// </summary>
-        Nonzero
+        Nonzero = 1
     }
 }

--- a/src/ImageSharp.Drawing/Shapes/Path.cs
+++ b/src/ImageSharp.Drawing/Shapes/Path.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System;
@@ -153,17 +153,7 @@ namespace SixLabors.Shapes
             yield return this;
         }
 
-        /// <summary>
-        /// Based on a line described by <paramref name="start" /> and <paramref name="end" />
-        /// populate a buffer for all points on the polygon that the line intersects.
-        /// </summary>
-        /// <param name="start">The start point of the line.</param>
-        /// <param name="end">The end point of the line.</param>
-        /// <param name="buffer">The buffer that will be populated with intersections.</param>
-        /// <param name="offset">The offset within the buffer</param>
-        /// <returns>
-        /// The number of intersections populated into the buffer.
-        /// </returns>
+        /// <inheritdoc />
         public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
         {
             return this.InnerPath.FindIntersections(start, end, buffer.AsSpan(offset));
@@ -173,6 +163,18 @@ namespace SixLabors.Shapes
         public int FindIntersections(PointF start, PointF end, Span<PointF> buffer)
         {
             return this.InnerPath.FindIntersections(start, end, buffer);
+        }
+
+        /// <inheritdoc />
+        public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset, IntersectionRule intersectionRule)
+        {
+            return this.InnerPath.FindIntersections(start, end, buffer.AsSpan(offset), intersectionRule);
+        }
+
+        /// <inheritdoc />
+        public int FindIntersections(PointF start, PointF end, Span<PointF> buffer, IntersectionRule intersectionRule)
+        {
+            return this.InnerPath.FindIntersections(start, end, buffer, intersectionRule);
         }
 
         /// <summary>

--- a/src/ImageSharp.Drawing/Shapes/RectangularPolygon.cs
+++ b/src/ImageSharp.Drawing/Shapes/RectangularPolygon.cs
@@ -221,18 +221,13 @@ namespace SixLabors.Shapes
             return Vector2.Clamp(point, this.topLeft, this.bottomRight) == (Vector2)point;
         }
 
-        /// <summary>
-        /// Based on a line described by <paramref name="start"/> and <paramref name="end"/>
-        /// populate a buffer for all points on the edges of the <see cref="RectangularPolygon"/>
-        /// that the line intersects.
-        /// </summary>
-        /// <param name="start">The start point of the line.</param>
-        /// <param name="end">The end point of the line.</param>
-        /// <param name="buffer">The buffer that will be populated with intersections.</param>
-        /// <param name="offset">The starting offset within the buffer</param>
-        /// <returns>
-        /// The number of intersections populated into the buffer.
-        /// </returns>
+        /// <inheritdoc />
+        public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset, IntersectionRule intersectionRule)
+        {
+            return this.FindIntersections(start, end, buffer.AsSpan(offset), intersectionRule);
+        }
+
+        /// <inheritdoc />
         public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
         {
             Span<PointF> subBuffer = buffer.AsSpan(offset);
@@ -240,7 +235,7 @@ namespace SixLabors.Shapes
         }
 
         /// <inheritdoc />
-        public int FindIntersections(PointF start, PointF end, Span<PointF> buffer)
+        public int FindIntersections(PointF start, PointF end, Span<PointF> buffer, IntersectionRule intersectionRule)
         {
             int offset = 0;
             int discovered = 0;
@@ -270,6 +265,12 @@ namespace SixLabors.Shapes
             }
 
             return discovered;
+        }
+
+        /// <inheritdoc />
+        public int FindIntersections(PointF start, PointF end, Span<PointF> buffer)
+        {
+            return this.FindIntersections(start, end, buffer, IntersectionRule.OddEven);
         }
 
         /// <summary>

--- a/src/ImageSharp.Drawing/Utils/QuickSort.cs
+++ b/src/ImageSharp.Drawing/Utils/QuickSort.cs
@@ -80,5 +80,161 @@ namespace SixLabors.ImageSharp.Utils
                 Swap(ref Unsafe.Add(ref data0, i), ref Unsafe.Add(ref data0, j));
             }
         }
+
+        /// <summary>
+        /// Sorts the elements of <paramref name="data"/> in ascending order
+        /// </summary>
+        /// <param name="sortable">The items to sort on</param>
+        /// <param name="data">The items to sort</param>
+        public static void Sort<T>(Span<float> sortable, Span<T> data)
+        {
+            if (sortable.Length != data.Length)
+            {
+                throw new Exception("both spans must be the same length");
+            }
+
+            if (sortable.Length < 2)
+            {
+                return;
+            }
+
+            if (sortable.Length == 2)
+            {
+                if (sortable[0] > sortable[1])
+                {
+                    Swap(ref sortable[0], ref sortable[1]);
+                    Swap(ref data[0], ref data[1]);
+                }
+
+                return;
+            }
+
+            Sort(ref sortable[0], 0, sortable.Length - 1, ref data[0]);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Swap<T>(ref T left, ref T right)
+        {
+            T tmp = left;
+            left = right;
+            right = tmp;
+        }
+
+        private static void Sort<T>(ref float data0, int lo, int hi, ref T dataToSort)
+        {
+            if (lo < hi)
+            {
+                int p = Partition(ref data0, lo, hi, ref dataToSort);
+                Sort(ref data0, lo, p, ref dataToSort);
+                Sort(ref data0, p + 1, hi, ref dataToSort);
+            }
+        }
+
+        private static int Partition<T>(ref float data0, int lo, int hi, ref T dataToSort)
+        {
+            float pivot = Unsafe.Add(ref data0, lo);
+            int i = lo - 1;
+            int j = hi + 1;
+            while (true)
+            {
+                do
+                {
+                    i = i + 1;
+                }
+                while (Unsafe.Add(ref data0, i) < pivot && i < hi);
+
+                do
+                {
+                    j = j - 1;
+                }
+                while (Unsafe.Add(ref data0, j) > pivot && j > lo);
+
+                if (i >= j)
+                {
+                    return j;
+                }
+
+                Swap(ref Unsafe.Add(ref data0, i), ref Unsafe.Add(ref data0, j));
+                Swap(ref Unsafe.Add(ref dataToSort, i), ref Unsafe.Add(ref dataToSort, j));
+            }
+        }
+
+        /// <summary>
+        /// Sorts the elements of <paramref name="sortable"/> in ascending order, and swapping items in <paramref name="data1"/> and <paramref name="data2"/> in sequance with them.
+        /// </summary>
+        /// <param name="sortable">The items to sort on</param>
+        /// <param name="data1">The set of items to sort</param>
+        /// <param name="data2">The 2nd set of items to sort</param>
+        public static void Sort<T1, T2>(Span<float> sortable, Span<T1> data1, Span<T2> data2)
+        {
+            if (sortable.Length != data1.Length)
+            {
+                throw new Exception("both spans must be the same length");
+            }
+
+            if (sortable.Length != data2.Length)
+            {
+                throw new Exception("both spans must be the same length");
+            }
+
+            if (sortable.Length < 2)
+            {
+                return;
+            }
+
+            if (sortable.Length == 2)
+            {
+                if (sortable[0] > sortable[1])
+                {
+                    Swap(ref sortable[0], ref sortable[1]);
+                    Swap(ref data1[0], ref data1[1]);
+                    Swap(ref data2[0], ref data2[1]);
+                }
+
+                return;
+            }
+
+            Sort(ref sortable[0], 0, sortable.Length - 1, ref data1[0], ref data2[0]);
+        }
+
+        private static void Sort<T1, T2>(ref float data0, int lo, int hi, ref T1 dataToSort1, ref T2 dataToSort2)
+        {
+            if (lo < hi)
+            {
+                int p = Partition(ref data0, lo, hi, ref dataToSort1, ref dataToSort2);
+                Sort(ref data0, lo, p, ref dataToSort1, ref dataToSort2);
+                Sort(ref data0, p + 1, hi, ref dataToSort1, ref dataToSort2);
+            }
+        }
+
+        private static int Partition<T1, T2>(ref float data0, int lo, int hi, ref T1 dataToSort1, ref T2 dataToSort2)
+        {
+            float pivot = Unsafe.Add(ref data0, lo);
+            int i = lo - 1;
+            int j = hi + 1;
+            while (true)
+            {
+                do
+                {
+                    i = i + 1;
+                }
+                while (Unsafe.Add(ref data0, i) < pivot && i < hi);
+
+                do
+                {
+                    j = j - 1;
+                }
+                while (Unsafe.Add(ref data0, j) > pivot && j > lo);
+
+                if (i >= j)
+                {
+                    return j;
+                }
+
+                Swap(ref Unsafe.Add(ref data0, i), ref Unsafe.Add(ref data0, j));
+                Swap(ref Unsafe.Add(ref dataToSort1, i), ref Unsafe.Add(ref dataToSort1, j));
+                Swap(ref Unsafe.Add(ref dataToSort2, i), ref Unsafe.Add(ref dataToSort2, j));
+            }
+        }
     }
 }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -31,6 +31,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" IsImplicitlyDefined="true" />
     <PackageReference Include="xunit" IsImplicitlyDefined="true" />
     <PackageReference Include="xunit.runner.visualstudio" IsImplicitlyDefined="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(codecov)' == 'true' AND '$(IsTestProject)' == 'true'">
     <PackageReference Include="coverlet.collector" IsImplicitlyDefined="true" />
     <PackageReference Include="coverlet.msbuild" IsImplicitlyDefined="true" />
   </ItemGroup>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -25,7 +25,7 @@
 
   <!--Code coverage specific settings-->
   <!--https://github.com/tonerdo/coverlet-->
-  <PropertyGroup Condition="'$(codecov)' == 'true'">
+  <PropertyGroup Condition="'$(codecov)' == 'true' AND '$(IsTestProject)' == 'true'">
     <CollectCoverage>true</CollectCoverage>
     <UseSourceLink>true</UseSourceLink>
     <CoverletOutputFormat>opencover</CoverletOutputFormat>

--- a/tests/ImageSharp.Drawing.Benchmarks/Drawing/DrawText.cs
+++ b/tests/ImageSharp.Drawing.Benchmarks/Drawing/DrawText.cs
@@ -94,7 +94,7 @@ namespace SixLabors.ImageSharp.Drawing.Benchmarks
 
                 Shapes.IPathCollection glyphs = Shapes.TextBuilder.GenerateGlyphs(text, style);
 
-                var pathOptions = (GraphicsOptions)options;
+                var pathOptions = new ShapeGraphicsOptions((GraphicsOptions)options);
                 if (brush != null)
                 {
                     source.Fill(pathOptions, brush, glyphs);

--- a/tests/ImageSharp.Drawing.Benchmarks/Drawing/DrawTextOutline.cs
+++ b/tests/ImageSharp.Drawing.Benchmarks/Drawing/DrawTextOutline.cs
@@ -99,7 +99,7 @@ namespace SixLabors.ImageSharp.Drawing.Benchmarks
 
                 Shapes.IPathCollection glyphs = Shapes.TextBuilder.GenerateGlyphs(text, style);
 
-                var pathOptions = (GraphicsOptions)options;
+                var pathOptions = new ShapeGraphicsOptions((GraphicsOptions)options);
                 if (brush != null)
                 {
                     source.Fill(pathOptions, brush, glyphs);

--- a/tests/ImageSharp.Drawing.Tests/Drawing/FillPolygonTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/FillPolygonTests.cs
@@ -6,6 +6,7 @@ using System.Numerics;
 
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
+using SixLabors.Primitives;
 using SixLabors.Shapes;
 
 using Xunit;
@@ -149,6 +150,69 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
                 c => c.Fill(color, polygon),
                 appendSourceFileOrDescription: false,
                 appendPixelTypeToFileName: false);
+        }
+
+        [Theory]
+        [WithSolidFilledImages(60, 60, "Blue", PixelTypes.Rgba32)]
+        public void Fill_IntersectionRules_OddEven<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (var img = provider.GetImage())
+            {
+                img.Mutate(c => c.FillPolygon(
+                    new ShapeGraphicsOptions
+                    {
+                        IntersectionRule = IntersectionRule.OddEven,
+                    },
+                    Color.HotPink,
+                    new PointF(10, 30),
+                    new PointF(10, 20),
+                    new PointF(50, 20),
+                    new PointF(50, 50),
+                    new PointF(20, 50),
+                    new PointF(20, 10),
+                    new PointF(30, 10),
+                    new PointF(30, 40),
+                    new PointF(40, 40),
+                    new PointF(30, 40)));
+
+                Assert.Equal(Color.HotPink.ToPixel<TPixel>(), img[35, 35]);
+
+                provider.Utility.SaveTestOutputFile(img);
+            }
+        }
+
+        [Theory]
+        [WithSolidFilledImages(60, 60, "Blue", PixelTypes.Rgba32)]
+        public void Fill_IntersectionRules_Nonzero<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            using (var img = provider.GetImage())
+            {
+                var poly = new Polygon(new LinearLineSegment(
+                    new PointF(10, 30),
+                    new PointF(10, 20)), new LinearLineSegment(
+                    new PointF(50, 20),
+                    new PointF(50, 50)), new LinearLineSegment(
+                    new PointF(20, 50),
+                    new PointF(20, 10)), new LinearLineSegment(
+                    new PointF(30, 10),
+                    new PointF(30, 40)), new LinearLineSegment(
+                    new PointF(40, 40),
+                    new PointF(30, 40),
+                    new PointF(10, 30)));
+                img.Mutate(c => c.Fill(
+                    new ShapeGraphicsOptions
+                    {
+                        IntersectionRule = IntersectionRule.Nonzero,
+                    },
+                    Color.HotPink,
+                    poly));
+
+                provider.Utility.SaveTestOutputFile(img);
+
+                Assert.Equal(Color.Blue.ToPixel<TPixel>(), img[35, 35]);
+            }
         }
     }
 }

--- a/tests/ImageSharp.Drawing.Tests/Drawing/FillPolygonTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/FillPolygonTests.cs
@@ -159,12 +159,8 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
         {
             using (var img = provider.GetImage())
             {
-                img.Mutate(c => c.FillPolygon(
-                    new ShapeGraphicsOptions
-                    {
-                        IntersectionRule = IntersectionRule.OddEven,
-                    },
-                    Color.HotPink,
+
+                var poly = new Polygon(new LinearLineSegment(
                     new PointF(10, 30),
                     new PointF(10, 20),
                     new PointF(50, 20),
@@ -174,11 +170,20 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
                     new PointF(30, 10),
                     new PointF(30, 40),
                     new PointF(40, 40),
-                    new PointF(30, 40)));
+                    new PointF(40, 30),
+                    new PointF(10, 30)));
 
-                Assert.Equal(Color.HotPink.ToPixel<TPixel>(), img[35, 35]);
+                img.Mutate(c => c.Fill(
+                    new ShapeGraphicsOptions
+                    {
+                        IntersectionRule = IntersectionRule.OddEven,
+                    },
+                    Color.HotPink,
+                    poly));
 
                 provider.Utility.SaveTestOutputFile(img);
+
+                Assert.Equal(Color.Blue.ToPixel<TPixel>(), img[25, 25]);
             }
         }
 
@@ -187,19 +192,20 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
         public void Fill_IntersectionRules_Nonzero<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : struct, IPixel<TPixel>
         {
+            Configuration.Default.MaxDegreeOfParallelism = 1;
             using (var img = provider.GetImage())
             {
                 var poly = new Polygon(new LinearLineSegment(
                     new PointF(10, 30),
-                    new PointF(10, 20)), new LinearLineSegment(
+                    new PointF(10, 20),
                     new PointF(50, 20),
-                    new PointF(50, 50)), new LinearLineSegment(
+                    new PointF(50, 50),
                     new PointF(20, 50),
-                    new PointF(20, 10)), new LinearLineSegment(
+                    new PointF(20, 10),
                     new PointF(30, 10),
-                    new PointF(30, 40)), new LinearLineSegment(
-                    new PointF(40, 40),
                     new PointF(30, 40),
+                    new PointF(40, 40),
+                    new PointF(40, 30),
                     new PointF(10, 30)));
                 img.Mutate(c => c.Fill(
                     new ShapeGraphicsOptions
@@ -210,8 +216,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
                     poly));
 
                 provider.Utility.SaveTestOutputFile(img);
-
-                Assert.Equal(Color.Blue.ToPixel<TPixel>(), img[35, 35]);
+                Assert.Equal(Color.HotPink.ToPixel<TPixel>(), img[25, 25]);
             }
         }
     }

--- a/tests/ImageSharp.Drawing.Tests/Drawing/FillRegionProcessorTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/FillRegionProcessorTests.cs
@@ -119,7 +119,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
         {
             public override Rectangle Bounds => new Rectangle(-100, -10, 10, 10);
 
-            public override int Scan(float y, Span<float> buffer, Configuration configuration)
+            public override int Scan(float y, Span<float> buffer, Configuration configuration, IntersectionRule intersectionRule)
             {
                 if (y < 5)
                 {
@@ -146,7 +146,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
 
             public int ScanInvocationCounter { get; private set; }
 
-            public override int Scan(float y, Span<float> buffer, Configuration configuration)
+            public override int Scan(float y, Span<float> buffer, Configuration configuration, IntersectionRule intersectionRule)
             {
                 this.ScanInvocationCounter++;
                 return 0;

--- a/tests/ImageSharp.Drawing.Tests/Drawing/Paths/FillPath.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/Paths/FillPath.cs
@@ -15,9 +15,9 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing.Paths
 {
     public class FillPath : BaseImageOperationsExtensionTest
     {
-        private static readonly GraphicsOptionsComparer graphicsOptionsComparer = new GraphicsOptionsComparer();
+        private static readonly ShapeGraphicsOptionsComparer graphicsOptionsComparer = new ShapeGraphicsOptionsComparer();
 
-        GraphicsOptions nonDefault = new GraphicsOptions { Antialias = false };
+        ShapeGraphicsOptions nonDefault = new GraphicsOptions { Antialias = false };
         Color color = Color.HotPink;
         SolidBrush brush = Brushes.Solid(Rgba32.HotPink);
         IPath path = new Path(new LinearLineSegment(new SixLabors.Primitives.PointF[] {
@@ -50,7 +50,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing.Paths
             this.operations.Fill(this.nonDefault, this.brush, this.path);
             var processor = this.Verify<FillRegionProcessor>();
 
-            Assert.Equal(this.nonDefault, processor.Options, graphicsOptionsComparer);
+            Assert.Equal(this.nonDefault, processor.ShapeOptions, graphicsOptionsComparer);
 
             ShapeRegion region = Assert.IsType<ShapeRegion>(processor.Region);
             Polygon polygon = Assert.IsType<Polygon>(region.Shape);

--- a/tests/ImageSharp.Drawing.Tests/Drawing/Paths/FillPath.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/Paths/FillPath.cs
@@ -81,7 +81,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing.Paths
             this.operations.Fill(this.nonDefault, this.color, this.path);
             var processor = this.Verify<FillRegionProcessor>();
 
-            Assert.Equal(this.nonDefault, processor.Options);
+            Assert.Equal(this.nonDefault, processor.ShapeOptions);
 
             ShapeRegion region = Assert.IsType<ShapeRegion>(processor.Region);
             Polygon polygon = Assert.IsType<Polygon>(region.Shape);

--- a/tests/ImageSharp.Drawing.Tests/Drawing/Paths/ShapeRegionTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/Paths/ShapeRegionTests.cs
@@ -28,12 +28,13 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing.Paths
             public abstract int MaxIntersections { get; }
             public abstract float Length { get; }
 
-            public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
+
+            public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset, IntersectionRule intersectionRule)
             {
                 return this.FindIntersections(start, end, buffer, 0);
             }
 
-            public int FindIntersections(PointF s, PointF e, Span<PointF> buffer)
+            public int FindIntersections(PointF s, PointF e, Span<PointF> buffer, IntersectionRule intersectionRule)
             {
                 Assert.Equal(this.TestYToScan, s.Y);
                 Assert.Equal(this.TestYToScan, e.Y);
@@ -44,6 +45,12 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing.Paths
 
                 return this.TestFindIntersectionsResult;
             }
+
+            public int FindIntersections(PointF start, PointF end, PointF[] buffer, int offset)
+                => FindIntersections(start, end, buffer, offset, IntersectionRule.OddEven);
+
+            public int FindIntersections(PointF s, PointF e, Span<PointF> buffer)
+                => FindIntersections(s, e, buffer, IntersectionRule.OddEven);
 
             public int TestFindIntersectionsInvocationCounter { get; private set; }
             public virtual int TestYToScan => 10;
@@ -97,7 +104,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing.Paths
             int yToScan = path.TestYToScan;
             var region = new ShapeRegion(path);
 
-            int i = region.Scan(yToScan, new float[path.TestFindIntersectionsResult], Configuration.Default);
+            int i = region.Scan(yToScan, new float[path.TestFindIntersectionsResult], Configuration.Default, IntersectionRule.OddEven);
 
             Assert.Equal(path.TestFindIntersectionsResult, i);
             Assert.Equal(1, path.TestFindIntersectionsInvocationCounter);

--- a/tests/ImageSharp.Drawing.Tests/ImageSharp.Drawing.Tests.csproj
+++ b/tests/ImageSharp.Drawing.Tests/ImageSharp.Drawing.Tests.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(Configuration)' == 'Debug'">netcoreapp3.1</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <DebugSymbols>True</DebugSymbols>

--- a/tests/ImageSharp.Drawing.Tests/ImageSharp.Drawing.Tests.csproj
+++ b/tests/ImageSharp.Drawing.Tests/ImageSharp.Drawing.Tests.csproj
@@ -10,6 +10,8 @@
     <AssemblyName>SixLabors.ImageSharp.Tests</AssemblyName>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <RootNamespace>SixLabors.ImageSharp.Drawing.Tests</RootNamespace>
+    <!--Used to show test project to dotnet test-->
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ImageSharp.Drawing.Tests/Shapes/InternalPathExtensions.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/InternalPathExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Six Labors and contributors.
+// Copyright (c) Six Labors and contributors.
 // Licensed under the Apache License, Version 2.0.
 
 using System.Buffers;
@@ -16,13 +16,13 @@ namespace SixLabors.Shapes
         /// <param name="start">The start.</param>
         /// <param name="end">The end.</param>
         /// <returns>The points along the line the intersect with the boundaries of the polygon.</returns>
-        internal static IEnumerable<PointF> FindIntersections(this InternalPath path, Vector2 start, Vector2 end)
+        internal static IEnumerable<PointF> FindIntersections(this InternalPath path, Vector2 start, Vector2 end, IntersectionRule intersectionRule = IntersectionRule.OddEven)
         {
             var results = new List<PointF>();
             PointF[] buffer = ArrayPool<PointF>.Shared.Rent(path.PointCount);
             try
             {
-                int hits = path.FindIntersections(start, end, buffer);
+                int hits = path.FindIntersections(start, end, buffer, intersectionRule);
                 for (int i = 0; i < hits; i++)
                 {
                     results.Add(buffer[i]);

--- a/tests/ImageSharp.Drawing.Tests/Shapes/InternalPathTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/InternalPathTests.cs
@@ -230,16 +230,6 @@ namespace SixLabors.Shapes.Tests
             Assert.Empty(buffer);
         }
 
-        [Fact]
-        public void Intersections_Diagonal_and_straight_Hit()
-        {
-            var shape = new InternalPath(new LinearLineSegment(new PointF(0, 0), new PointF(4, 4)), false);
-
-            PointF[] buffer = shape.FindIntersections(new PointF(3, 10), new PointF(3, 0)).ToArray();
-
-            Assert.Single(buffer);
-            Assert.Equal(new PointF(3, 3), buffer[0]);
-        }
 
         [Fact]
         public void Intersections_Diagonal_and_straight_NoHit()
@@ -249,6 +239,47 @@ namespace SixLabors.Shapes.Tests
             PointF[] buffer = shape.FindIntersections(new PointF(3, 10), new PointF(3, 3.5f)).ToArray();
 
             Assert.Empty(buffer);
+        }
+
+
+        [Fact]
+        public void Intersections_IntersectionRule_OddEven()
+        {
+            var shape = new InternalPath(new LinearLineSegment(
+                new PointF(3, 1),
+                new PointF(2, 1),
+                new PointF(2, 5),
+                new PointF(5, 5),
+                new PointF(5, 2),
+                new PointF(1, 2),
+                new PointF(1, 3),
+                new PointF(4, 3),
+                new PointF(4, 4),
+                new PointF(4, 3)), true);
+
+            PointF[] buffer = shape.FindIntersections(new PointF(2.5f, 0), new PointF(2.5f, 6), IntersectionRule.OddEven).ToArray();
+
+            Assert.Equal(4, buffer.Length);
+        }
+
+        [Fact]
+        public void Intersections_IntersectionRule_Nonezero()
+        {
+            var shape = new InternalPath(new LinearLineSegment(
+                new PointF(3, 1),
+                new PointF(2, 1),
+                new PointF(2, 5),
+                new PointF(5, 5),
+                new PointF(5, 2),
+                new PointF(1, 2),
+                new PointF(1, 3),
+                new PointF(4, 3),
+                new PointF(4, 4),
+                new PointF(4, 3)), true);
+
+            PointF[] buffer = shape.FindIntersections(new PointF(2.5f, 0), new PointF(2.5f, 6), IntersectionRule.Nonzero).ToArray();
+
+            Assert.Equal(2, buffer.Length);
         }
     }
 }

--- a/tests/ImageSharp.Drawing.Tests/Shapes/InternalPathTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/InternalPathTests.cs
@@ -246,18 +246,18 @@ namespace SixLabors.Shapes.Tests
         public void Intersections_IntersectionRule_OddEven()
         {
             var shape = new InternalPath(new LinearLineSegment(
-                new PointF(3, 1),
-                new PointF(2, 1),
-                new PointF(2, 5),
-                new PointF(5, 5),
-                new PointF(5, 2),
-                new PointF(1, 2),
                 new PointF(1, 3),
-                new PointF(4, 3),
+                new PointF(1, 2),
+                new PointF(5, 2),
+                new PointF(5, 5),
+                new PointF(2, 5),
+                new PointF(2, 1),
+                new PointF(3, 1),
+                new PointF(3, 4),
                 new PointF(4, 4),
-                new PointF(4, 3)), true);
+                new PointF(3, 4)), true);
 
-            PointF[] buffer = shape.FindIntersections(new PointF(2.5f, 0), new PointF(2.5f, 6), IntersectionRule.OddEven).ToArray();
+            PointF[] buffer = shape.FindIntersections(new PointF(0, 2.5f), new PointF(6, 2.5f), IntersectionRule.OddEven).ToArray();
 
             Assert.Equal(4, buffer.Length);
         }
@@ -266,18 +266,18 @@ namespace SixLabors.Shapes.Tests
         public void Intersections_IntersectionRule_Nonezero()
         {
             var shape = new InternalPath(new LinearLineSegment(
-                new PointF(3, 1),
-                new PointF(2, 1),
-                new PointF(2, 5),
-                new PointF(5, 5),
-                new PointF(5, 2),
-                new PointF(1, 2),
                 new PointF(1, 3),
-                new PointF(4, 3),
+                new PointF(1, 2),
+                new PointF(5, 2),
+                new PointF(5, 5),
+                new PointF(2, 5),
+                new PointF(2, 1),
+                new PointF(3, 1),
+                new PointF(3, 4),
                 new PointF(4, 4),
-                new PointF(4, 3)), true);
+                new PointF(3, 4)), true);
 
-            PointF[] buffer = shape.FindIntersections(new PointF(2.5f, 0), new PointF(2.5f, 6), IntersectionRule.Nonzero).ToArray();
+            PointF[] buffer = shape.FindIntersections(new PointF(0, 2.5f), new PointF(6, 2.5f), IntersectionRule.Nonzero).ToArray();
 
             Assert.Equal(2, buffer.Length);
         }

--- a/tests/ImageSharp.Drawing.Tests/TestUtilities/GraphicsOptionsComparer.cs
+++ b/tests/ImageSharp.Drawing.Tests/TestUtilities/GraphicsOptionsComparer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System.Collections.Generic;
+using SixLabors.ImageSharp.Processing;
 
 namespace SixLabors.ImageSharp.Drawing.Tests.TestUtilities
 {
@@ -17,5 +18,20 @@ namespace SixLabors.ImageSharp.Drawing.Tests.TestUtilities
         }
 
         public int GetHashCode(GraphicsOptions obj) => obj.GetHashCode();
+    }
+
+    public class ShapeGraphicsOptionsComparer : IEqualityComparer<ShapeGraphicsOptions>
+    {
+        public bool Equals(ShapeGraphicsOptions x, ShapeGraphicsOptions y)
+        {
+            return x.AlphaCompositionMode == y.AlphaCompositionMode
+                && x.Antialias == y.Antialias
+                && x.AntialiasSubpixelDepth == y.AntialiasSubpixelDepth
+                && x.BlendPercentage == y.BlendPercentage
+                && x.ColorBlendingMode == y.ColorBlendingMode
+                && x.IntersectionRule  == y.IntersectionRule;
+        }
+
+        public int GetHashCode(ShapeGraphicsOptions obj) => obj.GetHashCode();
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Shapes/Drawing now supports both oddeven (old & default) and nonzero.

#### Nonzero 
![Fill_IntersectionRules_Nonzero_Rgba32_Solid60x60_(0,0,255,255)](https://user-images.githubusercontent.com/166440/72681932-370dbb00-3ac0-11ea-99bf-e991beb99308.png)

#### Oddeven (current)
![Fill_IntersectionRules_OddEven_Rgba32_Solid60x60_(0,0,255,255)](https://user-images.githubusercontent.com/166440/72681933-370dbb00-3ac0-11ea-836b-fdd7217ea4bf.png)

Required me adding a new GraphicsOptions variant to expose the new shape specific properties. (inline with TextGraphicsOptions)  

resolves #14
resolves #11 



