### PR TITLE
Render glyphs with nonzero IntersectionRule

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
@@ -87,6 +87,17 @@ namespace SixLabors.ImageSharp.Drawing.Processing.Processors.Text
                             int startY = operation.Location.Y;
                             int startX = operation.Location.X;
                             int offsetSpan = 0;
+
+                            if (startX + buffer.Height < 0)
+                            {
+                                continue;
+                            }
+
+                            if (startX + buffer.Width < 0)
+                            {
+                                continue;
+                            }
+
                             if (startX < 0)
                             {
                                 offsetSpan = -startX;
@@ -335,7 +346,7 @@ namespace SixLabors.ImageSharp.Drawing.Processing.Processors.Text
                         {
                             var start = new PointF(path.Bounds.Left - 1, subPixel);
                             var end = new PointF(path.Bounds.Right + 1, subPixel);
-                            int pointsFound = path.FindIntersections(start, end, intersectionSpan);
+                            int pointsFound = path.FindIntersections(start, end, intersectionSpan, IntersectionRule.Nonzero);
 
                             if (pointsFound == 0)
                             {

--- a/src/ImageSharp.Drawing/Shapes/ComplexPolygon.cs
+++ b/src/ImageSharp.Drawing/Shapes/ComplexPolygon.cs
@@ -193,25 +193,7 @@ namespace SixLabors.ImageSharp.Drawing
         /// <inheritdoc />
         public int FindIntersections(PointF start, PointF end, Span<PointF> buffer, IntersectionRule intersectionRule)
         {
-            if (this.internalPaths == null)
-            {
-                lock (this.paths)
-                {
-                    if (this.internalPaths == null)
-                    {
-                        this.internalPaths = new List<InternalPath>(this.paths.Length);
-
-                        foreach (var p in this.paths)
-                        {
-                            foreach (var s in p.Flatten())
-                            {
-                                var ip = new InternalPath(s.Points, s.IsClosed);
-                                this.internalPaths.Add(ip);
-                            }
-                        }
-                    }
-                }
-            }
+            this.EnsureInternalPathsInitalized();
 
             int totalAdded = 0;
             Orientation[] orientations = ArrayPool<Orientation>.Shared.Rent(buffer.Length); // the largest number of intersections of any sub path of the set is the max size with need for this buffer.
@@ -248,6 +230,29 @@ namespace SixLabors.ImageSharp.Drawing
             }
 
             return totalAdded;
+        }
+
+        private void EnsureInternalPathsInitalized()
+        {
+            if (this.internalPaths == null)
+            {
+                lock (this.paths)
+                {
+                    if (this.internalPaths == null)
+                    {
+                        this.internalPaths = new List<InternalPath>(this.paths.Length);
+
+                        foreach (var p in this.paths)
+                        {
+                            foreach (var s in p.Flatten())
+                            {
+                                var ip = new InternalPath(s.Points, s.IsClosed);
+                                this.internalPaths.Add(ip);
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/src/ImageSharp.Drawing/Shapes/ComplexPolygon.cs
+++ b/src/ImageSharp.Drawing/Shapes/ComplexPolygon.cs
@@ -197,14 +197,17 @@ namespace SixLabors.ImageSharp.Drawing
             {
                 lock (this.paths)
                 {
-                    this.internalPaths = new List<InternalPath>(this.paths.Length);
-
-                    foreach (var p in this.paths)
+                    if (this.internalPaths == null)
                     {
-                        foreach (var s in p.Flatten())
+                        this.internalPaths = new List<InternalPath>(this.paths.Length);
+
+                        foreach (var p in this.paths)
                         {
-                            var ip = new InternalPath(s.Points, s.IsClosed);
-                            this.internalPaths.Add(ip);
+                            foreach (var s in p.Flatten())
+                            {
+                                var ip = new InternalPath(s.Points, s.IsClosed);
+                                this.internalPaths.Add(ip);
+                            }
                         }
                     }
                 }

--- a/src/ImageSharp.Drawing/Shapes/ComplexPolygon.cs
+++ b/src/ImageSharp.Drawing/Shapes/ComplexPolygon.cs
@@ -193,18 +193,18 @@ namespace SixLabors.ImageSharp.Drawing
         /// <inheritdoc />
         public int FindIntersections(PointF start, PointF end, Span<PointF> buffer, IntersectionRule intersectionRule)
         {
-            if (internalPaths == null)
+            if (this.internalPaths == null)
             {
-                lock (paths)
+                lock (this.paths)
                 {
-                    internalPaths = new List<InternalPath>(paths.Length);
+                    this.internalPaths = new List<InternalPath>(this.paths.Length);
 
                     foreach (var p in this.paths)
                     {
                         foreach (var s in p.Flatten())
                         {
                             var ip = new InternalPath(s.Points, s.IsClosed);
-                            internalPaths.Add(ip);
+                            this.internalPaths.Add(ip);
                         }
                     }
                 }

--- a/src/ImageSharp.Drawing/Shapes/ComplexPolygon.cs
+++ b/src/ImageSharp.Drawing/Shapes/ComplexPolygon.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Orientation = SixLabors.ImageSharp.Drawing.InternalPath.Orientation;
 
 namespace SixLabors.ImageSharp.Drawing
 {
@@ -15,6 +17,7 @@ namespace SixLabors.ImageSharp.Drawing
     public sealed class ComplexPolygon : IPath
     {
         private readonly IPath[] paths;
+        private List<InternalPath> internalPaths = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexPolygon" /> class.
@@ -190,21 +193,56 @@ namespace SixLabors.ImageSharp.Drawing
         /// <inheritdoc />
         public int FindIntersections(PointF start, PointF end, Span<PointF> buffer, IntersectionRule intersectionRule)
         {
+            if (internalPaths == null)
+            {
+                lock (paths)
+                {
+                    internalPaths = new List<InternalPath>(paths.Length);
+
+                    foreach (var p in this.paths)
+                    {
+                        foreach (var s in p.Flatten())
+                        {
+                            var ip = new InternalPath(s.Points, s.IsClosed);
+                            internalPaths.Add(ip);
+                        }
+                    }
+                }
+            }
+
             int totalAdded = 0;
-            for (int i = 0; i < this.paths.Length; i++)
+            Orientation[] orientations = ArrayPool<Orientation>.Shared.Rent(buffer.Length); // the largest number of intersections of any sub path of the set is the max size with need for this buffer.
+            Span<Orientation> orientationsSpan = orientations;
+            try
             {
-                Span<PointF> subBuffer = buffer.Slice(totalAdded);
-                int added = this.paths[i].FindIntersections(start, end, subBuffer, intersectionRule);
-                totalAdded += added;
-            }
+                foreach (var ip in this.internalPaths)
+                {
+                    Span<PointF> subBuffer = buffer.Slice(totalAdded);
+                    Span<Orientation> subOrientationsSpan = orientationsSpan.Slice(totalAdded);
 
-            Span<float> distances = stackalloc float[totalAdded];
-            for (int i = 0; i < totalAdded; i++)
+                    var position = ip.FindIntersectionsWithOrientation(start, end, subBuffer, subOrientationsSpan);
+                    totalAdded += position;
+                }
+
+                Span<float> distances = stackalloc float[totalAdded];
+                for (int i = 0; i < totalAdded; i++)
+                {
+                    distances[i] = Vector2.DistanceSquared(start, buffer[i]);
+                }
+
+                var activeBuffer = buffer.Slice(0, totalAdded);
+                var activeOrientationsSpan = orientationsSpan.Slice(0, totalAdded);
+                QuickSort.Sort(distances, activeBuffer, activeOrientationsSpan);
+
+                if (intersectionRule == IntersectionRule.Nonzero)
+                {
+                    totalAdded = InternalPath.ApplyNonZeroIntersectionRules(activeBuffer, activeOrientationsSpan);
+                }
+            }
+            finally
             {
-                distances[i] = Vector2.DistanceSquared(start, buffer[i]);
+                ArrayPool<Orientation>.Shared.Return(orientations);
             }
-
-            QuickSort.Sort(distances, buffer.Slice(0, totalAdded));
 
             return totalAdded;
         }

--- a/src/ImageSharp.Drawing/Shapes/InternalPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/InternalPath.cs
@@ -88,7 +88,7 @@ namespace SixLabors.ImageSharp.Drawing
         /// <summary>
         /// the orrientateion of an point form a line
         /// </summary>
-        private enum Orientation
+        internal enum Orientation
         {
             /// <summary>
             /// Point is colienear
@@ -190,6 +190,41 @@ namespace SixLabors.ImageSharp.Drawing
         /// <returns>number of intersections hit</returns>
         public int FindIntersections(PointF start, PointF end, Span<PointF> buffer, IntersectionRule intersectionRule)
         {
+            Orientation[] orientations = ArrayPool<Orientation>.Shared.Rent(buffer.Length);
+            try
+            {
+                Span<Orientation> orientationsSpan = orientations.AsSpan(0, buffer.Length);
+                var position = this.FindIntersectionsWithOrientation(start, end, buffer, orientationsSpan);
+
+                var activeBuffer = buffer.Slice(0, position);
+                var activeOrientationsSpan = orientationsSpan.Slice(0, position);
+
+                // intersection rules only really apply to closed paths
+                if (intersectionRule == IntersectionRule.Nonzero && this.closedPath)
+                {
+                    position = ApplyNonZeroIntersectionRules(activeBuffer, activeOrientationsSpan);
+                }
+
+                return position;
+
+            }
+            finally
+            {
+                ArrayPool<Orientation>.Shared.Return(orientations);
+            }
+        }
+
+        /// <summary>
+        /// Based on a line described by <paramref name="start" /> and <paramref name="end" />
+        /// populates a buffer for all points on the path that the line intersects.
+        /// </summary>
+        /// <param name="start">The start.</param>
+        /// <param name="end">The end.</param>
+        /// <param name="buffer">The buffer.</param>
+        /// <param name="orientationsSpan">The buffer for storeing the orientation of each intersection.</param>
+        /// <returns>number of intersections hit</returns>
+        public int FindIntersectionsWithOrientation(PointF start, PointF end, Span<PointF> buffer, Span<Orientation> orientationsSpan)
+        {
             if (this.points.Length < 2)
             {
                 return 0;
@@ -212,8 +247,9 @@ namespace SixLabors.ImageSharp.Drawing
             Vector2 lastPoint = MaxVector;
 
             PassPointData[] precaclulate = ArrayPool<PassPointData>.Shared.Rent(this.points.Length);
-            Orientation[] orientations = ArrayPool<Orientation>.Shared.Rent(this.points.Length);
-            Span<Orientation> orientationsSpan = orientations.AsSpan(0, this.points.Length);
+
+            //Orientation[] orientations = ArrayPool<Orientation>.Shared.Rent(this.points.Length);
+            //Span<Orientation> orientationsSpan = orientations.AsSpan(0, this.points.Length);
             Span<PassPointData> precaclulateSpan = precaclulate.AsSpan(0, this.points.Length);
 
             try
@@ -341,47 +377,52 @@ namespace SixLabors.ImageSharp.Drawing
                     distances[i] = Vector2.DistanceSquared(startVector, buffer[i]);
                 }
 
-                QuickSort.Sort(distances, buffer.Slice(0, position), orientationsSpan.Slice(0, position));
-
-                // intersection rules only really apply to closed paths
-                if (intersectionRule == IntersectionRule.Nonzero && this.closedPath)
-                {
-                    int newpositions = 0;
-                    int tracker = 0;
-                    for (int i = 0; i < position; i++)
-                    {
-                        bool include = tracker == 0;
-                        switch (orientationsSpan[i])
-                        {
-                            case Orientation.Clockwise:
-                                tracker++;
-                                break;
-                            case Orientation.Counterclockwise:
-                                tracker--;
-                                break;
-                            case Orientation.Colinear:
-                            default:
-                                break;
-                        }
-
-                        if (include || tracker == 0)
-                        {
-                            buffer[newpositions] = buffer[i];
-                            newpositions++;
-                        }
-                    }
-
-                    position = newpositions;
-                }
+                var activeBuffer = buffer.Slice(0, position);
+                var activeOrientationsSpan = orientationsSpan.Slice(0, position);
+                QuickSort.Sort(distances, activeBuffer, activeOrientationsSpan);
 
                 return position;
             }
             finally
             {
-                ArrayPool<Orientation>.Shared.Return(orientations);
                 ArrayPool<PassPointData>.Shared.Return(precaclulate);
             }
         }
+
+        internal static int ApplyNonZeroIntersectionRules(Span<PointF> buffer, Span<Orientation> orientationsSpan)
+        {
+            int newpositions = 0;
+            int tracker = 0;
+            int diff = 0;
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                bool include = tracker == 0;
+                switch (orientationsSpan[i])
+                {
+                    case Orientation.Counterclockwise:
+                        diff = 1;
+                        break;
+                    case Orientation.Clockwise:
+                        diff = -1;
+                        break;
+                    case Orientation.Colinear:
+                    default:
+                        diff *= -1;
+                        break;
+                }
+
+                tracker += diff;
+
+                if (include || tracker == 0)
+                {
+                    buffer[newpositions] = buffer[i];
+                    newpositions++;
+                }
+            }
+
+            return newpositions;
+        }
+
 
         /// <summary>
         /// Determines if the specified point is inside or outside the path.

--- a/src/ImageSharp.Drawing/Shapes/InternalPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/InternalPath.cs
@@ -206,7 +206,6 @@ namespace SixLabors.ImageSharp.Drawing
                 }
 
                 return position;
-
             }
             finally
             {
@@ -420,7 +419,6 @@ namespace SixLabors.ImageSharp.Drawing
 
             return newpositions;
         }
-
 
         /// <summary>
         /// Determines if the specified point is inside or outside the path.

--- a/src/ImageSharp.Drawing/Shapes/InternalPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/InternalPath.cs
@@ -248,8 +248,6 @@ namespace SixLabors.ImageSharp.Drawing
 
             PassPointData[] precaclulate = ArrayPool<PassPointData>.Shared.Rent(this.points.Length);
 
-            //Orientation[] orientations = ArrayPool<Orientation>.Shared.Rent(this.points.Length);
-            //Span<Orientation> orientationsSpan = orientations.AsSpan(0, this.points.Length);
             Span<PassPointData> precaclulateSpan = precaclulate.AsSpan(0, this.points.Length);
 
             try

--- a/tests/ImageSharp.Drawing.Tests/Drawing/Text/DrawTextOnImageTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/Text/DrawTextOnImageTests.cs
@@ -84,6 +84,22 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing.Text
 
 
         [Theory]
+        [WithSolidFilledImages(200, 200, "White", PixelTypes.Rgba32)]
+        public void OpenSansJWithNoneZeroShouldntExtendPastGlyphe<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using (Image<TPixel> img = provider.GetImage())
+            {
+                Font font = CreateFont("OpenSans-Regular.ttf", 50);
+                Color color = Color.Black;
+
+                img.Mutate(ctx => ctx.DrawText(TestText, font, Color.Black, new PointF(-50, 2)));
+
+                Assert.Equal(Color.White.ToPixel<TPixel>(), img[173, 2]);
+            }
+        }
+
+        [Theory]
         [WithSolidFilledImages(200, 100, "White", PixelTypes.Rgba32, 50, 0, 0, "SixLaborsSampleAB.woff", AB)]
         [WithSolidFilledImages(900, 100, "White", PixelTypes.Rgba32, 50, 0, 0, "OpenSans-Regular.ttf", TestText)]
         [WithSolidFilledImages(400, 40, "White", PixelTypes.Rgba32, 20, 0, 0, "OpenSans-Regular.ttf", TestText)]

--- a/tests/ImageSharp.Drawing.Tests/Shapes/ComplexPolygonTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/ComplexPolygonTests.cs
@@ -43,6 +43,58 @@ namespace SixLabors.ImageSharp.Drawing.Tests
         private ITestOutputHelper Output { get; }
 
         [Fact]
+        public void NonezeroFindIntersections()
+        {
+            var simplePath1 = new Polygon(new LinearLineSegment(
+                              new PointF(2, 1),
+                              new PointF(2, 5),
+                              new PointF(3, 5),
+                              new PointF(3, 1)));
+
+            var simplePath2 = new Polygon(new LinearLineSegment(
+                            new PointF(1, 2),
+                            new PointF(1, 3),
+                            new PointF(4, 3),
+                            new PointF(4, 2)));
+
+            var complex = new ComplexPolygon(simplePath1, simplePath2);
+
+            var buffer = new PointF[10];
+            var points = complex.FindIntersections(new PointF(0, 2.5f), new PointF(6, 2.5f), buffer, 0, IntersectionRule.Nonzero);
+
+            Assert.Equal(2, points);
+            Assert.Equal(1, buffer[0].X);
+            Assert.Equal(4, buffer[1].X);
+        }
+
+        [Fact]
+        public void OddEvenFindIntersections()
+        {
+            var simplePath1 = new Polygon(new LinearLineSegment(
+                              new PointF(2, 1),
+                              new PointF(2, 5),
+                              new PointF(3, 5),
+                              new PointF(3, 1)));
+
+            var simplePath2 = new Polygon(new LinearLineSegment(
+                            new PointF(1, 2),
+                            new PointF(1, 3),
+                            new PointF(4, 3),
+                            new PointF(4, 2)));
+
+            var complex = new ComplexPolygon(simplePath1, simplePath2);
+
+            var buffer = new PointF[10];
+            var points = complex.FindIntersections(new PointF(0, 2.5f), new PointF(6, 2.5f), buffer, 0, IntersectionRule.OddEven);
+
+            Assert.Equal(4, points);
+            Assert.Equal(1, buffer[0].X);
+            Assert.Equal(2, buffer[1].X);
+            Assert.Equal(3, buffer[2].X);
+            Assert.Equal(4, buffer[3].X);
+        }
+
+        [Fact]
         public void MissingIntersection()
         {
             float[] data = new float[6];


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Ensure we render glyphs using nonzero rule to prevent holes when using certain fonts.

Also fixed a side issue when starting trying to render a glyph completely to the left/above the image.

Fixes #35