### PR TITLE
Optermization for filling rectangles to gain access to fast fill path

### DIFF
--- a/tests/ImageSharp.Drawing.Tests/Processing/FillPathProcessorTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Processing/FillPathProcessorTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Drawing.Processing.Processors.Drawing;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Drawing.Tests.Processing
+{
+    public class FillPathProcessorTests
+    {
+        [Fact]
+        public void OtherShape()
+        {
+            var imageSize = new Rectangle(0, 0, 500, 500);
+            var path = new EllipsePolygon(1, 1, 23);
+            var processor = new FillPathProcessor(new ImageSharp.Drawing.Processing.ShapeGraphicsOptions()
+            {
+                GraphicsOptions = {
+                    Antialias = true
+                }
+            }, Brushes.Solid(Color.Red), path);
+            var pixelProcessor = processor.CreatePixelSpecificProcessor<Rgba32>(null, null, imageSize);
+
+            Assert.IsType<FillRegionProcessor<Rgba32>>(pixelProcessor);
+        }
+
+        [Fact]
+        public void RectangleFloatAndAntialias()
+        {
+            var imageSize = new Rectangle(0, 0, 500, 500);
+            var floatRect = new RectangleF(10.5f, 10.5f, 400.6f, 400.9f);
+            var expectedRect = new Rectangle(10, 10, 400, 400);
+            var path = new RectangularPolygon(floatRect);
+            var processor = new FillPathProcessor(new ImageSharp.Drawing.Processing.ShapeGraphicsOptions()
+            {
+                GraphicsOptions = {
+                    Antialias = true
+                }
+            }, Brushes.Solid(Color.Red), path);
+            var pixelProcessor = processor.CreatePixelSpecificProcessor<Rgba32>(null, null, imageSize);
+
+            Assert.IsType<FillRegionProcessor<Rgba32>>(pixelProcessor);
+        }
+
+        [Fact]
+        public void IntRectangle()
+        {
+            var imageSize = new Rectangle(0, 0, 500, 500);
+            var expectedRect = new Rectangle(10, 10, 400, 400);
+            var path = new RectangularPolygon(expectedRect);
+            var processor = new FillPathProcessor(new ImageSharp.Drawing.Processing.ShapeGraphicsOptions()
+            {
+                GraphicsOptions = {
+                    Antialias = true
+                }
+            }, Brushes.Solid(Color.Red), path);
+            var pixelProcessor = processor.CreatePixelSpecificProcessor<Rgba32>(null, null, imageSize);
+
+            var fill = Assert.IsType<FillProcessor<Rgba32>>(pixelProcessor);
+            Assert.Equal(expectedRect, fill.GetProtectedValue<Rectangle>("SourceRectangle"));
+        }
+
+        [Fact]
+        public void FloatRectAntialiasingOff()
+        {
+            var imageSize = new Rectangle(0, 0, 500, 500);
+            var floatRect = new RectangleF(10.5f, 10.5f, 400.6f, 400.9f);
+            var expectedRect = new Rectangle(10, 10, 400, 400);
+            var path = new RectangularPolygon(floatRect);
+            var processor = new FillPathProcessor(new ImageSharp.Drawing.Processing.ShapeGraphicsOptions()
+            {
+                GraphicsOptions = {
+                    Antialias = false
+                }
+            }, Brushes.Solid(Color.Red), path);
+            var pixelProcessor = processor.CreatePixelSpecificProcessor<Rgba32>(null, null, imageSize);
+
+            var fill = Assert.IsType<FillProcessor<Rgba32>>(pixelProcessor);
+            Assert.Equal(expectedRect, fill.GetProtectedValue<Rectangle>("SourceRectangle"));
+        }
+    }
+
+    internal static class ReflectionHelpers
+    {
+        internal static T GetProtectedValue<T>(this object obj, string name)
+        {
+            return (T)obj.GetType()
+                    .GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.FlattenHierarchy)
+                    .Single(x => x.Name == name)
+                    .GetValue(obj);
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
This special cases Filling `RectangularPolygon`s if it lines up exactly to int boundries or  anti-aliasing is off then it uses the `FillProcessor` rather than the slower `FillRegionProcessor` (which deals with anti-alising and rasterization)

Fixes #40

Dependent on #39