### PR TITLE
Prevent internal path throwing index out of range for an empty path

### DIFF
--- a/src/ImageSharp.Drawing/Shapes/InternalPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/InternalPath.cs
@@ -86,6 +86,11 @@ namespace SixLabors.ImageSharp.Drawing
                 this.Bounds = new RectangleF(minX, minY, maxX - minX, maxY - minY);
                 this.Length = this.points.Sum(x => x.Length);
             }
+            else
+            {
+                this.Bounds = RectangleF.Empty;
+                this.Length = 0;
+            }
         }
 
         /// <summary>

--- a/src/ImageSharp.Drawing/Shapes/InternalPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/InternalPath.cs
@@ -76,13 +76,16 @@ namespace SixLabors.ImageSharp.Drawing
             this.points = points;
             this.closedPath = isClosedPath;
 
-            float minX = this.points.Min(x => x.Point.X);
-            float maxX = this.points.Max(x => x.Point.X);
-            float minY = this.points.Min(x => x.Point.Y);
-            float maxY = this.points.Max(x => x.Point.Y);
+            if (this.points.Length > 0)
+            {
+                float minX = this.points.Min(x => x.Point.X);
+                float maxX = this.points.Max(x => x.Point.X);
+                float minY = this.points.Min(x => x.Point.Y);
+                float maxY = this.points.Max(x => x.Point.Y);
 
-            this.Bounds = new RectangleF(minX, minY, maxX - minX, maxY - minY);
-            this.Length = this.points.Sum(x => x.Length);
+                this.Bounds = new RectangleF(minX, minY, maxX - minX, maxY - minY);
+                this.Length = this.points.Sum(x => x.Length);
+            }
         }
 
         /// <summary>
@@ -684,10 +687,14 @@ namespace SixLabors.ImageSharp.Drawing
         private static PointData[] Simplify(IEnumerable<PointF> vectors, bool isClosed)
         {
             PointF[] points = vectors.ToArray();
-            var results = new List<PointData>();
 
             int polyCorners = points.Length;
+            if (polyCorners == 0)
+            {
+                return Array.Empty<PointData>();
+            }
 
+            var results = new List<PointData>();
             Vector2 lastPoint = points[0];
 
             if (!isClosed)

--- a/tests/ImageSharp.Drawing.Tests/Issues/Issues-48.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issues-48.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Drawing.Tests.Issues
+{
+    // https://github.com/SixLabors/ImageSharp.Drawing/issues/48
+    // index out of rang error if zero length ChildPath of a ComplexPolygon
+    public class Issues_48
+    {
+        [Fact]
+        public void DoNotThowIfPolygonHasZeroLength()
+        {
+            var emptyPoly = new ComplexPolygon(new Polygon());
+            emptyPoly.FindIntersections(new PointF(0, 0), new PointF(100, 100));
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

This adds logic to `InternalPath` to cope with paths with zero length.

Resolves #48 
Resolves #47 