### PR TITLE
Check length before using index.

### DIFF
--- a/src/ImageSharp.Drawing/Shapes/InternalPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/InternalPath.cs
@@ -719,16 +719,18 @@ namespace SixLabors.ImageSharp.Drawing
                     prev--;
                     if (prev == 0)
                     {
-                        // all points are common, shouldn't match anything
+                        // All points are common, shouldn't match anything
+                        int next = points.Length == 1 ? 0 : 1;
                         results.Add(
                             new PointData
                             {
                                 Point = points[0],
                                 Orientation = Orientation.Colinear,
-                                Segment = new Segment(points[0], points[1]),
+                                Segment = new Segment(points[0], points[next]),
                                 Length = 0,
                                 TotalLength = 0
                             });
+
                         return results.ToArray();
                     }
                 }

--- a/tests/ImageSharp.Drawing.Tests/Issues/Issues-55-59.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issues-55-59.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Drawing.Tests.Issues
+{
+    // https://github.com/SixLabors/ImageSharp.Drawing/issues/55
+    // https://github.com/SixLabors/ImageSharp.Drawing/issues/59
+    public class Issues_55_59
+    {
+        [Fact]
+        public void SimplifyOutOfRangeExceptionDrawLines()
+        {
+            PointF[] line = new[]
+            {
+                new PointF(1, 48),
+                new PointF(5, 77),
+                new PointF(35, 0),
+                new PointF(33, 8),
+                new PointF(11, 23)
+            };
+
+            using var image = new Image<Rgba32>(100, 100);
+            image.Mutate(imageContext => imageContext.DrawLines(new Rgba32(255, 0, 0), 1, line));
+        }
+
+        [Fact]
+        public void SimplifyOutOfRangeExceptionDraw()
+        {
+            var path = new Path(
+                new LinearLineSegment(new PointF(592.0153f, 1156.238f), new PointF(592.4992f, 1157.138f)),
+                new LinearLineSegment(new PointF(592.4992f, 1157.138f), new PointF(593.3998f, 1156.654f)),
+                new LinearLineSegment(new PointF(593.3998f, 1156.654f), new PointF(592.916f, 1155.754f)),
+                new LinearLineSegment(new PointF(592.916f, 1155.754f), new PointF(592.0153f, 1156.238f))
+            );
+
+            using var image = new Image<Rgba32>(2000, 2000);
+            image.Mutate(imageContext => imageContext.Draw(new Rgba32(255, 0, 0), 1, path));
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
`InternalPath` is attempting to use an out of range index when the length of the simplified point array is 1.

I assumed that the rest of the reduction code is sound and that since the previous logic assigned a segment with two identical values, simply reusing the value at `0` was ok. 

This fixes #55, and fixes #59

<!-- Thanks for contributing to ImageSharp! -->
