### PR TITLE
Skip filling rectangles if the effective fill area is zero width or height

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/FillProcessor{TPixel}.cs
@@ -29,10 +29,15 @@ namespace SixLabors.ImageSharp.Drawing.Processing.Processors.Drawing
         /// <inheritdoc/>
         protected override void OnFrameApply(ImageFrame<TPixel> source)
         {
+            var interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
+            if (interest.Width == 0 || interest.Height == 0)
+            {
+                return;
+            }
+
             Configuration configuration = this.Configuration;
             IBrush brush = this.definition.Brush;
             GraphicsOptions options = this.definition.Options;
-            var interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
 
             // If there's no reason for blending, then avoid it.
             if (this.IsSolidBrushWithoutBlending(out SolidBrush solidBrush))

--- a/tests/ImageSharp.Drawing.Tests/Issues/Issue_65.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issue_65.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Drawing.Tests.Issues
+{
+    public class Issue_65
+    {
+        [Theory]
+        [InlineData(-100)] //Crash
+        [InlineData(-99)]  //Fine
+        [InlineData(99)]   //Fine
+        [InlineData(100)]  //Crash
+        public void DrawRectactangleOutsideBoundsDrawingArea(int xpos)
+        {
+            int width = 100;
+            int height = 100;
+
+            using (var image = new Image<Rgba32>(width, height, Color.Red))
+            {
+                var rectangle = new Rectangle(xpos, 0, width, height);
+
+                image.Mutate(x => x.Fill(Color.Black, rectangle));
+            }
+        }
+
+        [Theory]
+        [InlineData(-110)] //Crash
+        [InlineData(-99)]  //Fine
+        [InlineData(99)]   //Fine
+        [InlineData(110)]  //Crash
+        public void DrawCircleOutsideBoundsDrawingArea(int xpos)
+        {
+            int width = 100;
+            int height = 100;
+
+            using (var image = new Image<Rgba32>(width, height, Color.Red))
+            {
+                var circle = new EllipsePolygon(xpos, 0, width, height);
+
+                image.Mutate(x => x.Fill(Color.Black, circle));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp! -->
fixes #65 