### PR TITLE
drop gitversion in favour of minver

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,31 +52,14 @@ jobs:
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
 
-            - name: Fetch Tags for GitVersion
-              run: |
-                  git fetch --tags
-
-            - name: Fetch master for GitVersion
-              if: github.ref != 'refs/heads/master'
-              run: git branch --create-reflog master origin/master
-
-            - name: Install GitVersion
-              uses: gittools/actions/setup-gitversion@v0.3
-              with:
-                  versionSpec: "5.1.x"
-
-            - name: Use GitVersion
-              id: gitversion # step id used as reference for output values
-              uses: gittools/actions/execute-gitversion@v0.3
-
             - name: Setup DotNet SDK
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: "3.1.101"
+                  dotnet-version: "3.1.x"
 
             - name: Build
               shell: pwsh
-              run: ./ci-build.ps1 "${{steps.gitversion.outputs.nuGetVersion}}" "${{matrix.options.framework}}"
+              run: ./ci-build.ps1 "${{matrix.options.framework}}"
 
             - name: Test
               shell: pwsh
@@ -112,33 +95,17 @@ jobs:
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
 
-            - name: Fetch Tags for GitVersion
-              run: |
-                  git fetch --tags
-
-            - name: Fetch master for GitVersion
-              if: github.ref != 'refs/heads/master'
-              run: git branch --create-reflog master origin/master
-
-            - name: Install GitVersion
-              uses: gittools/actions/setup-gitversion@v0.3
-              with:
-                  versionSpec: "5.1.x"
-
-            - name: Use GitVersion
-              id: gitversion # step id used as reference for output values
-              uses: gittools/actions/execute-gitversion@v0.3
-
             - name: Setup DotNet SDK
               uses: actions/setup-dotnet@v1
               with:
-                  dotnet-version: "3.1.101"
+                  dotnet-version: "3.1.x"
 
             - name: Pack
               shell: pwsh
-              run: ./ci-pack.ps1 "${{steps.gitversion.outputs.nuGetVersion}}"
+              run: ./ci-pack.ps1
 
             - name: Publish to MyGet
               shell: pwsh
-              run: nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
-              # TODO: If github.ref starts with 'refs/tags' then it was tag push and we can optionally push out package to nuget.org
+              run: |
+                  nuget.exe push .\artifacts\*.nupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v2/package
+                  nuget.exe push .\artifacts\*.snupkg ${{secrets.MYGET_TOKEN}} -Source https://www.myget.org/F/sixlabors/api/v3/index.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,6 @@
     <DebugType Condition="'$(codecov)' != ''">full</DebugType>
     <NullableContextOptions>disable</NullableContextOptions>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <SignAssembly>false</SignAssembly>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
@@ -71,6 +70,12 @@
     <VersionPrefix>0.0.1</VersionPrefix>
     <VersionPrefix Condition="'$(packageversion)' != ''">$(PackageVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
+  </PropertyGroup>
+
+  <!--MinVer Properties for versioning-->
+  <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerVerbosity>normal</MinVerVerbosity>
   </PropertyGroup>
 
   <!-- Default settings that are otherwise undefined -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,6 +22,9 @@
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0" />
     <PackageReference Update="StyleCop.Analyzers" PrivateAssets="All" Version="1.1.118" />
 
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Update="MinVer" PrivateAssets="All" Version="2.3.0" />
+
     <!--Src Dependencies-->
     <PackageReference Update="SixLabors.Fonts" Version="1.0.0-beta0013" />
     <PackageReference Update="SixLabors.ImageSharp" Version="1.0.0-rc0003" />

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,0 @@
-continuous-delivery-fallback-tag: ci
-branches:
-    master:
-        tag: unstable
-        mode: ContinuousDeployment
-    pull-request:
-        tag: pr

--- a/ci-build.ps1
+++ b/ci-build.ps1
@@ -1,7 +1,5 @@
 param(
-  [Parameter(Mandatory, Position = 0)]
-  [string]$version,
-  [Parameter(Mandatory = $true, Position = 1)]
+  [Parameter(Mandatory = $true, Position = 0)]
   [string]$targetFramework
 )
 
@@ -10,4 +8,4 @@ dotnet clean -c Release
 $repositoryUrl = "https://github.com/$env:GITHUB_REPOSITORY"
 
 # Building for a specific framework.
-dotnet build -c Release -f $targetFramework /p:packageversion=$version /p:RepositoryUrl=$repositoryUrl
+dotnet build -c Release -f $targetFramework /p:RepositoryUrl=$repositoryUrl

--- a/ci-pack.ps1
+++ b/ci-pack.ps1
@@ -1,11 +1,6 @@
-param(
-  [Parameter(Mandatory, Position = 0)]
-  [string]$version
-)
-
 dotnet clean -c Release
 
 $repositoryUrl = "https://github.com/$env:GITHUB_REPOSITORY"
 
 # Building for packing and publishing.
-dotnet pack -c Release --output "$PSScriptRoot/artifacts" /p:packageversion=$version /p:RepositoryUrl=$repositoryUrl
+dotnet pack -c Release --output "$PSScriptRoot/artifacts" /p:RepositoryUrl=$repositoryUrl

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,6 +26,19 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <!--Add deterministic builds in CI-->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
   <ItemGroup>
     <!--TODO: Delete this once tests Stylecop issues are fixed-->
     <PackageReference Include="StyleCop.Analyzers" IsImplicitlyDefined="true"  />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -20,6 +20,17 @@
     <GeneratedInternalsVisibleToFile Condition="'$(GeneratedInternalsVisibleToFile)' == ''">$(IntermediateOutputPath)$(MSBuildProjectName).InternalsVisibleTo$(DefaultLanguageSourceExtension)</GeneratedInternalsVisibleToFile>
   </PropertyGroup>
 
+  <!-- Workaround for running Coverlet with Determenistic builds -->
+  <!-- https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/DeterministicBuild.md -->
+  <Target Name="CoverletGetPathMap"
+            DependsOnTargets="InitializeSourceRootMappedPaths"
+            Returns="@(_LocalTopLevelSourceRoot)"
+            Condition="'$(DeterministicSourcePaths)' == 'true'">
+    <ItemGroup>
+      <_LocalTopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''"/>
+    </ItemGroup>
+  </Target>
+
   <ItemDefinitionGroup>
     <InternalsVisibleTo>
       <Visible>false</Visible>

--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -15,6 +15,8 @@
   <ItemGroup>
     <PackageReference Include="SixLabors.Fonts" />
     <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub"/>
+    <PackageReference Include="MinVer" PrivateAssets="All" />
   </ItemGroup>
 
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -25,8 +25,8 @@
 
   <ItemGroup>
     <!--Test Dependencies-->
-    <PackageReference Update="BenchmarkDotNet" Version="0.12.0" />
-    <PackageReference Update="coverlet.collector" Version="1.2.0" PrivateAssets="All"/>
+    <PackageReference Update="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Update="coverlet.collector" Version="1.3.0" PrivateAssets="All"/>
     <PackageReference Update="Magick.NET-Q16-AnyCPU" Version="7.14.4" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0-preview-20200116-01" />
     <PackageReference Update="Moq" Version="4.10.0" />
@@ -34,5 +34,5 @@
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
This is a port of the minver changes applied to the main ImageSharp repo as i'm getting sick of the gitversion randomly failing on some of the builds