### PR TITLE
Fix contribution links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# How to contribute to ImageSharp
+# How to contribute to SixLabors.ImageSharp.Drawing
 
 #### **Did you find a bug?**
 
-- Please **ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/SixLabors/ImageSharp/issues).
+- Please **ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/SixLabors/ImageSharp.Drawing/issues).
 
-- If you're unable to find an open issue addressing the problem, please [open a new one](https://github.com/SixLabors/ImageSharp/issues/new). Be sure to include a **title, the applicable version, a clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring. Please do not hijack existing issues.
+- If you're unable to find an open issue addressing the problem, please [open a new one](https://github.com/SixLabors/ImageSharp.Drawing/issues/new). Be sure to include a **title, the applicable version, a clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring. Please do not hijack existing issues.
 
 #### **Did you write a patch that fixes a bug?**
 
@@ -12,13 +12,19 @@
 
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 
-* Before submitting, please ensure that your code matches the existing coding patterns and practise as demonstrated in the repository. These follow strict Stylecop rules :cop:.
+* Before submitting, please ensure that your code matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
 
 #### **Do you intend to add a new feature or change an existing one?**
 
-* Suggest your change in the [ImageSharp Gitter Chat Room](https://gitter.im/ImageSharp/General) and start writing code.
+* Suggest your change in the [Ideas Discussions Channel](https://github.com/SixLabors/ImageSharp.Drawing/discussions?discussions_q=category%3AIdeas) and start writing code.
 
 * Do not open an issue on GitHub until you have collected positive feedback about the change. GitHub issues are primarily intended for bug reports and fixes.
+
+#### **Building**
+
+ * When first cloning the repo, make sure to run `git submodule update --init --recursive` otherwise the submodules (e.g. `shared-infrastructure`) will be missing.
+
+ * Run `dotnet build` in the root of the repo, or open the ImageSharp.Drawing.sln file in Visual Studio and build from there.
 
 #### **Running tests and Debugging**
 
@@ -27,14 +33,12 @@
 
 #### **Do you have questions about consuming the library or the source code?**
 
-* Ask any question about how to use ImageSharp in the [ImageSharp Gitter Chat Room](https://gitter.im/ImageSharp/General).
+* Ask any question about how to use SixLabors.ImageSharp in the [Help Discussions Channel](https://github.com/SixLabors/ImageSharp.Drawing/discussions?discussions_q=category%3AHelp).
 
 #### Code of Conduct  
 This project has adopted the code of conduct defined by the [Contributor Covenant](https://contributor-covenant.org/) to clarify expected behavior in our community.
 For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
 
-And please remember. ImageSharp is the work of a very, very, small number of developers who struggle balancing time to contribute to the project with family time and work commitments. We encourage you to pitch in and help make our vision of simple accessible imageprocessing available to all. Open Source can only exist with your help.
+And please remember. SixLabors.ImageSharp.Drawing is the work of a very, very, small number of developers who struggle balancing time to contribute to the project with family time and work commitments. We encourage you to pitch in and help make our vision of simple accessible image processing available to all. Open Source can only exist with your help.
 
 Thanks for reading!
-
-James Jackson-South :heart:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
     - name: Ask a Question
-      url: https://github.com/SixLabors/ImageSharp.Drawing/discussions/new?category_id=6331980
+      url: https://github.com/SixLabors/ImageSharp.Drawing/discussions?discussions_q=category%3AHelp
       about: Ask a question about this project.
     - name: Feature Request
-      url: https://github.com/SixLabors/ImageSharp.Drawing/discussions/new?category_id=6331981
+      url: https://github.com/SixLabors/ImageSharp.Drawing/discussions?discussions_q=category%3AIdeas
       about: Share ideas for new features for this project.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@
 ### Description
 <!-- A description of the changes proposed in the pull-request -->
 
-<!-- Thanks for contributing to ImageSharp! -->
+<!-- Thanks for contributing to ImageSharp.Drawing! -->


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Github changed the links path so our template links are returning 404. I've updated that and also fixed a couple of other docs issues.
<!-- Thanks for contributing to ImageSharp! -->
