### PR TITLE
Fix compatibility with .NET 5 SDK InternalsVisibleTo

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,11 +53,6 @@ jobs:
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
 
-            - name: Setup DotNet SDK
-              uses: actions/setup-dotnet@v1
-              with:
-                  dotnet-version: "3.1.x"
-
             - name: Build
               shell: pwsh
               run: ./ci-build.ps1 "${{matrix.options.framework}}"
@@ -70,7 +65,7 @@ jobs:
                   XUNIT_PATH: .\tests\ImageSharp.Drawing.Tests # Required for xunit
 
             - name: Update Codecov
-              uses: codecov/codecov-action@v1.0.7
+              uses: codecov/codecov-action@v1
               if: matrix.options.codecov == true && startsWith(github.repository, 'SixLabors')
               with:
                   flags: unittests
@@ -95,11 +90,6 @@ jobs:
                   git config --global core.longpaths true
                   git fetch --prune --unshallow
                   git submodule -q update --init --recursive
-
-            - name: Setup DotNet SDK
-              uses: actions/setup-dotnet@v1
-              with:
-                  dotnet-version: "3.1.x"
 
             - name: Pack
               shell: pwsh

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -44,9 +44,9 @@
     <PackageReference Include="StyleCop.Analyzers" IsImplicitlyDefined="true"  />
 
     <!-- DynamicProxyGenAssembly2 is needed so Moq can use our internals -->
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" PublicKey="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
-    <InternalsVisibleTo Include="SixLabors.ImageSharp.Tests"  PublicKey="$(SixLaborsPublicKey)" />
-    <InternalsVisibleTo Include="ImageSharp.Drawing.Benchmarks"  PublicKey="$(SixLaborsPublicKey)" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
+    <InternalsVisibleTo Include="SixLabors.ImageSharp.Tests"  Key="$(SixLaborsPublicKey)" />
+    <InternalsVisibleTo Include="ImageSharp.Drawing.Benchmarks"  Key="$(SixLaborsPublicKey)" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -46,10 +46,10 @@
           Condition="'$(Language)' == 'VB' or '$(Language)' == 'C#'"
           Inputs="$(MSBuildAllProjects)"
           Outputs="$(GeneratedInternalsVisibleToFile)">
-    <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute" AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity)" Condition="'%(InternalsVisibleTo.PublicKey)' == ''">
+    <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute" AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity)" Condition="'%(InternalsVisibleTo.Key)' == ''">
       <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
     </CreateItem>
-    <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute" AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity), PublicKey=%(InternalsVisibleTo.PublicKey)" Condition="'%(InternalsVisibleTo.PublicKey)' != ''">
+    <CreateItem Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute" AdditionalMetadata="_Parameter1=%(InternalsVisibleTo.Identity), PublicKey=%(InternalsVisibleTo.Key)" Condition="'%(InternalsVisibleTo.Key)' != ''">
       <Output TaskParameter="Include" ItemName="InternalsVisibleToAttribute" />
     </CreateItem>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Same thing as SixLabors/ImageSharp#1337. My Rider is configured with .NET 5 SDK so I need this now.