### PR TITLE
Fix IndexOutOfRangeException when drawing lines outside of image

### DIFF
--- a/src/ImageSharp.Drawing/Shapes/Rasterization/PolygonScanner.cs
+++ b/src/ImageSharp.Drawing/Shapes/Rasterization/PolygonScanner.cs
@@ -140,7 +140,7 @@ namespace SixLabors.ImageSharp.Drawing.Shapes.Rasterization
             int i1 = 0;
 
             // Do fake scans for the lines belonging to edge start and endpoints before minY
-            while (this.SubPixelY < this.minY)
+            while (this.SubPixelY < this.minY && i0 < this.edges.Length)
             {
                 this.EnterEdges();
                 this.LeaveEdges();

--- a/src/ImageSharp.Drawing/Shapes/Rasterization/PolygonScanner.cs
+++ b/src/ImageSharp.Drawing/Shapes/Rasterization/PolygonScanner.cs
@@ -140,7 +140,7 @@ namespace SixLabors.ImageSharp.Drawing.Shapes.Rasterization
             int i1 = 0;
 
             // Do fake scans for the lines belonging to edge start and endpoints before minY
-            while (this.SubPixelY < this.minY && i0 < this.edges.Length)
+            while (this.SubPixelY < this.minY)
             {
                 this.EnterEdges();
                 this.LeaveEdges();
@@ -151,12 +151,12 @@ namespace SixLabors.ImageSharp.Drawing.Shapes.Rasterization
 
                 if (y0 < y1)
                 {
-                    this.SubPixelY = y0;
+                    this.SubPixelY = y1;
                     i0++;
                 }
                 else
                 {
-                    this.SubPixelY = y1;
+                    this.SubPixelY = y0;
                     i1++;
                 }
             }

--- a/tests/ImageSharp.Drawing.Tests/Issues/Issue_28.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issue_28.cs
@@ -78,5 +78,54 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Issues
 
             Assert.All(locations, l => Assert.Equal(this.red, image[l.x, l.y]));
         }
+
+        [Fact]
+        public void DrawingLineAtTopWith1point5pxStrokeShouldDisplay()
+        {
+            using var image = new Image<Rgba32>(Configuration.Default, 100, 100, Color.Black);
+            image.Mutate(x => x
+                    .SetGraphicsOptions(g => g.Antialias = false)
+                    .DrawLines(
+                        this.red,
+                        1.5f,
+                        new PointF(0, 0),
+                        new PointF(100, 0)));
+
+            IEnumerable<(int x, int y)> locations = Enumerable.Range(0, 100).Select(i => (x: i, y: 0));
+            Assert.All(locations, l => Assert.Equal(this.red, image[l.x, l.y]));
+        }
+
+        [Fact]
+        public void DrawingLineAtTopWith2pxStrokeShouldDisplay()
+        {
+            using var image = new Image<Rgba32>(Configuration.Default, 100, 100, Color.Black);
+            image.Mutate(x => x
+                    .SetGraphicsOptions(g => g.Antialias = false)
+                    .DrawLines(
+                        this.red,
+                        2f,
+                        new PointF(0, 0),
+                        new PointF(100, 0)));
+
+            IEnumerable<(int x, int y)> locations = Enumerable.Range(0, 100).Select(i => (x: i, y: 0));
+            Assert.All(locations, l => Assert.Equal(this.red, image[l.x, l.y]));
+        }
+
+        [Fact]
+        public void DrawingLineAtTopWith3pxStrokeShouldDisplay()
+        {
+            using var image = new Image<Rgba32>(Configuration.Default, 100, 100, Color.Black);
+            image.Mutate(x => x
+                    .SetGraphicsOptions(g => g.Antialias = false)
+                    .DrawLines(
+                        this.red,
+                        3f,
+                        new PointF(0, 0),
+                        new PointF(100, 0)));
+
+            IEnumerable<(int x, int y)> locations = Enumerable.Range(0, 100).Select(i => (x: i, y: 0))
+                .Concat(Enumerable.Range(0, 100).Select(i => (x: i, y: 1)));
+            Assert.All(locations, l => Assert.Equal(this.red, image[l.x, l.y]));
+        }
     }
 }

--- a/tests/ImageSharp.Drawing.Tests/Issues/Issue_28_108.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issue_28_108.cs
@@ -10,19 +10,23 @@ using Xunit;
 
 namespace SixLabors.ImageSharp.Drawing.Tests.Issues
 {
-    public class Issue_28
+    public class Issue_28_108
     {
         private Rgba32 red = Color.Red.ToRgba32();
 
-        [Fact]
-        public void DrawingLineAtTopShouldDisplay()
+        [Theory]
+        [InlineData(1F)]
+        [InlineData(1.5F)]
+        [InlineData(2F)]
+        [InlineData(3F)]
+        public void DrawingLineAtTopShouldDisplay(float stroke)
         {
             using var image = new Image<Rgba32>(Configuration.Default, 100, 100, Color.Black);
             image.Mutate(x => x
                     .SetGraphicsOptions(g => g.Antialias = false)
                     .DrawLines(
                         this.red,
-                        1f,
+                        stroke,
                         new PointF(0, 0),
                         new PointF(100, 0)));
 
@@ -30,15 +34,19 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Issues
             Assert.All(locations, l => Assert.Equal(this.red, image[l.x, l.y]));
         }
 
-        [Fact]
-        public void DrawingLineAtBottomShouldDisplay()
+        [Theory]
+        [InlineData(1F)]
+        [InlineData(1.5F)]
+        [InlineData(2F)]
+        [InlineData(3F)]
+        public void DrawingLineAtBottomShouldDisplay(float stroke)
         {
             using var image = new Image<Rgba32>(Configuration.Default, 100, 100, Color.Black);
             image.Mutate(x => x
                     .SetGraphicsOptions(g => g.Antialias = false)
                     .DrawLines(
                         this.red,
-                        1f,
+                        stroke,
                         new PointF(0, 99),
                         new PointF(100, 99)));
 
@@ -46,15 +54,19 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Issues
             Assert.All(locations, l => Assert.Equal(this.red, image[l.x, l.y]));
         }
 
-        [Fact]
-        public void DrawingLineAtLeftShouldDisplay()
+        [Theory]
+        [InlineData(1F)]
+        [InlineData(1.5F)]
+        [InlineData(2F)]
+        [InlineData(3F)]
+        public void DrawingLineAtLeftShouldDisplay(float stroke)
         {
             using var image = new Image<Rgba32>(Configuration.Default, 100, 100, Color.Black);
             image.Mutate(x => x
                     .SetGraphicsOptions(g => g.Antialias = false)
                     .DrawLines(
                         this.red,
-                        1f,
+                        stroke,
                         new PointF(0, 0),
                         new PointF(0, 99)));
 
@@ -62,69 +74,23 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Issues
             Assert.All(locations, l => Assert.Equal(this.red, image[l.x, l.y]));
         }
 
-        [Fact]
-        public void DrawingLineAtRightShouldDisplay()
+        [Theory]
+        [InlineData(1F)]
+        [InlineData(1.5F)]
+        [InlineData(2F)]
+        [InlineData(3F)]
+        public void DrawingLineAtRightShouldDisplay(float stroke)
         {
             using var image = new Image<Rgba32>(Configuration.Default, 100, 100, Color.Black);
             image.Mutate(x => x
                     .SetGraphicsOptions(g => g.Antialias = false)
                     .DrawLines(
                         this.red,
-                        1f,
+                        stroke,
                         new PointF(99, 0),
                         new PointF(99, 99)));
 
             IEnumerable<(int x, int y)> locations = Enumerable.Range(0, 100).Select(i => (x: 99, y: i));
-
-            Assert.All(locations, l => Assert.Equal(this.red, image[l.x, l.y]));
-        }
-
-        [Fact]
-        public void DrawingLineAtTopWith1point5pxStrokeShouldDisplay()
-        {
-            using var image = new Image<Rgba32>(Configuration.Default, 100, 100, Color.Black);
-            image.Mutate(x => x
-                    .SetGraphicsOptions(g => g.Antialias = false)
-                    .DrawLines(
-                        this.red,
-                        1.5f,
-                        new PointF(0, 0),
-                        new PointF(100, 0)));
-
-            IEnumerable<(int x, int y)> locations = Enumerable.Range(0, 100).Select(i => (x: i, y: 0));
-            Assert.All(locations, l => Assert.Equal(this.red, image[l.x, l.y]));
-        }
-
-        [Fact]
-        public void DrawingLineAtTopWith2pxStrokeShouldDisplay()
-        {
-            using var image = new Image<Rgba32>(Configuration.Default, 100, 100, Color.Black);
-            image.Mutate(x => x
-                    .SetGraphicsOptions(g => g.Antialias = false)
-                    .DrawLines(
-                        this.red,
-                        2f,
-                        new PointF(0, 0),
-                        new PointF(100, 0)));
-
-            IEnumerable<(int x, int y)> locations = Enumerable.Range(0, 100).Select(i => (x: i, y: 0));
-            Assert.All(locations, l => Assert.Equal(this.red, image[l.x, l.y]));
-        }
-
-        [Fact]
-        public void DrawingLineAtTopWith3pxStrokeShouldDisplay()
-        {
-            using var image = new Image<Rgba32>(Configuration.Default, 100, 100, Color.Black);
-            image.Mutate(x => x
-                    .SetGraphicsOptions(g => g.Antialias = false)
-                    .DrawLines(
-                        this.red,
-                        3f,
-                        new PointF(0, 0),
-                        new PointF(100, 0)));
-
-            IEnumerable<(int x, int y)> locations = Enumerable.Range(0, 100).Select(i => (x: i, y: 0))
-                .Concat(Enumerable.Range(0, 100).Select(i => (x: i, y: 1)));
             Assert.All(locations, l => Assert.Equal(this.red, image[l.x, l.y]));
         }
     }

--- a/tests/ImageSharp.Drawing.Tests/Shapes/Scan/PolygonScannerTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/Scan/PolygonScannerTests.cs
@@ -426,6 +426,25 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Shapes.Scan
             this.TestScan(poly, 0, 2, 2, expected, intersectionRule);
         }
 
+        [Fact]
+        public void OutOfBounds()
+        {
+            IPath poly = PolygonFactory.CreatePolygon((1, -5), (5, -5), (5, -3), (10, -1), (10, 2), (12, 4), (1, 4));
+
+            FuzzyFloat[][] exected =
+            {
+                new FuzzyFloat[] { 1, 10 },
+                new FuzzyFloat[] { 1, 10 },
+                new FuzzyFloat[] { 1, 10 },
+                new FuzzyFloat[] { 1, 10 },
+                new FuzzyFloat[] { 1, 10 },
+                new FuzzyFloat[] { 1, 10.5 },
+                new FuzzyFloat[] { 1, 11 },
+            };
+
+            this.TestScan(poly, 0, 3, 2, exected);
+        }
+
         private static (float y, FuzzyFloat[] x) Empty(float y) => (y, new FuzzyFloat[0]);
 
         private static FuzzyFloat F(float x, float eps) => new FuzzyFloat(x, eps);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Updates `PolygonScanner` to correctly handle  scanlines outside of the image frame. Lines are still centered correctly.
Fixes #108 

[Angle starting and finishing outside of the frame](https://github.com/OleksandrKrutykh)
![angle](https://user-images.githubusercontent.com/385879/105431485-a414dd00-5c4d-11eb-91b0-6ff566f7daa9.png)

Stroke 3 Top
![t-3](https://user-images.githubusercontent.com/385879/105431494-a5460a00-5c4d-11eb-9970-07022186c175.png)

Stroke 3 Bottom
![b-3](https://user-images.githubusercontent.com/385879/105431486-a4ad7380-5c4d-11eb-864e-97048602afef.png)

Stroke 3 Left
![l-3](https://user-images.githubusercontent.com/385879/105431489-a4ad7380-5c4d-11eb-9700-f47b89035ae4.png)

Stroke 3 Right
![r-3](https://user-images.githubusercontent.com/385879/105431491-a5460a00-5c4d-11eb-9fb5-ba679aa7c63e.png)



<!-- Thanks for contributing to ImageSharp.Drawing! -->
