### PR TITLE
Allow implementing custom brush types

### DIFF
--- a/src/ImageSharp.Drawing/Processing/BrushApplicator.cs
+++ b/src/ImageSharp.Drawing/Processing/BrushApplicator.cs
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Drawing.Processing
         /// <param name="configuration">The configuration instance to use when performing operations.</param>
         /// <param name="options">The graphics options.</param>
         /// <param name="target">The target image frame.</param>
-        internal BrushApplicator(Configuration configuration, GraphicsOptions options, ImageFrame<TPixel> target)
+        protected BrushApplicator(Configuration configuration, GraphicsOptions options, ImageFrame<TPixel> target)
         {
             this.Configuration = configuration;
             this.Target = target;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #20 allowing custom brushes inheriting `BrushApplicator`

<!-- Thanks for contributing to ImageSharp.Drawing! -->
