### PR TITLE
enable image brush to be only draw a portion of the source image

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Processors/Drawing/RecursiveImageProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Drawing/RecursiveImageProcessor.cs
@@ -83,7 +83,7 @@ namespace SixLabors.ImageSharp.Drawing.Processing.Processors.Drawing
                 // Use an image brush to apply cloned image as the source for filling the shape.
                 // We pass explicit bounds to avoid the need to crop the clone;
                 RectangleF bounds = this.recursiveImageProcessor.Path.Bounds;
-                var brush = new ImageBrush(clone, new RectangleF(0, 0, bounds.Width, bounds.Height));
+                var brush = new ImageBrush(clone, bounds);
 
                 // Grab hold of an image processor that can fill paths with a brush to allow it to do the hard pixel pushing for us
                 var processor = new FillPathProcessor(this.recursiveImageProcessor.Options, brush, this.recursiveImageProcessor.Path);

--- a/tests/ImageSharp.Drawing.Tests/Drawing/ClipTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/ClipTests.cs
@@ -14,10 +14,11 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
     public class ClipTests
     {
         [Theory]
-        [WithBasicTestPatternImages(250, 350, PixelTypes.Rgba32, 0, 0)]
-        [WithBasicTestPatternImages(250, 350, PixelTypes.Rgba32, -20, -20)]
-        [WithBasicTestPatternImages(250, 350, PixelTypes.Rgba32, 20, 20)]
-        public void Clip<TPixel>(TestImageProvider<TPixel> provider, float dx, float dy)
+        [WithBasicTestPatternImages(250, 350, PixelTypes.Rgba32, 0, 0, 0.5)]
+        [WithBasicTestPatternImages(250, 350, PixelTypes.Rgba32, -20, -20, 0.5)]
+        [WithBasicTestPatternImages(250, 350, PixelTypes.Rgba32, 20, 20, 0.5)]
+        [WithBasicTestPatternImages(250, 350, PixelTypes.Rgba32, 40, 60, 0.2)]
+        public void Clip<TPixel>(TestImageProvider<TPixel> provider, float dx, float dy, float sizeMult)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             FormattableString testDetails = $"offset_x{dx}_y{dy}";
@@ -25,7 +26,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
                 x =>
                 {
                     Size size = x.GetCurrentSize();
-                    int outerRadii = Math.Min(size.Width, size.Height) / 2;
+                    int outerRadii = (int)(Math.Min(size.Width, size.Height) * sizeMult);
                     var star = new Star(new PointF(size.Width / 2, size.Height / 2), 5, outerRadii / 2, outerRadii);
 
                     var builder = Matrix3x2.CreateTranslation(new Vector2(dx, dy));

--- a/tests/ImageSharp.Drawing.Tests/Drawing/FillPolygonTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/FillPolygonTests.cs
@@ -225,6 +225,33 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
         }
 
         [Theory]
+        [WithBasicTestPatternImages(250, 350, PixelTypes.Rgba32, TestImages.Png.Ducky)]
+        [WithBasicTestPatternImages(250, 350, PixelTypes.Rgba32, TestImages.Bmp.Car)]
+        public void FillPolygon_ImageBrush_Rect<TPixel>(TestImageProvider<TPixel> provider, string brushImageName)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            PointF[] simplePath =
+                {
+                    new Vector2(10, 10), new Vector2(200, 50), new Vector2(50, 200)
+                };
+
+            using (var brushImage = Image.Load<TPixel>(TestFile.Create(brushImageName).Bytes))
+            {
+                float top = brushImage.Height / 4;
+                float left = brushImage.Width / 4;
+                float height = top * 2;
+                float width = left * 2;
+
+                var brush = new ImageBrush(brushImage, new RectangleF(left, top, width, height));
+
+                provider.RunValidatingProcessorTest(
+                    c => c.FillPolygon(brush, simplePath),
+                    System.IO.Path.GetFileNameWithoutExtension(brushImageName) + "_rect",
+                    appendSourceFileOrDescription: false);
+            }
+        }
+
+        [Theory]
         [WithBasicTestPatternImages(250, 250, PixelTypes.Rgba32)]
         public void Fill_RectangularPolygon<TPixel>(TestImageProvider<TPixel> provider)
             where TPixel : unmanaged, IPixel<TPixel>

--- a/tests/Images/ReferenceOutput/Drawing/ClipTests/Clip_offset_x40_y60.png
+++ b/tests/Images/ReferenceOutput/Drawing/ClipTests/Clip_offset_x40_y60.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a30ca888127436a977aef4672d5cc4af3e6fd636a05844fcc08430ccf7ebdd9
+size 4515

--- a/tests/Images/ReferenceOutput/Drawing/FillPolygonTests/FillPolygon_ImageBrush_Rect_Rgba32_Car_rect.png
+++ b/tests/Images/ReferenceOutput/Drawing/FillPolygonTests/FillPolygon_ImageBrush_Rect_Rgba32_Car_rect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f72faff5b4d42f008e149912e32c5b017417c78057def3d8950fa3fdde0c8b2
+size 48547

--- a/tests/Images/ReferenceOutput/Drawing/FillPolygonTests/FillPolygon_ImageBrush_Rect_Rgba32_ducky_rect.png
+++ b/tests/Images/ReferenceOutput/Drawing/FillPolygonTests/FillPolygon_ImageBrush_Rect_Rgba32_ducky_rect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31bc372733f303b5732dda94f920464394703b7b3e13358ccc2fc9a50e186ae4
+size 30815


### PR DESCRIPTION
@JimBobSquarePants  This is just the changes for you #150 branch that correctly clips the source image while still supporting target/destination offsetting (that's what the pre-existing region was for).

NOTE@ This is targeting branch of #150 