### PR TITLE
Fix defaults documentation of ShapeOptions and TextOptions properties

### DIFF
--- a/src/ImageSharp.Drawing/Processing/ShapeOptions.cs
+++ b/src/ImageSharp.Drawing/Processing/ShapeOptions.cs
@@ -25,7 +25,8 @@ namespace SixLabors.ImageSharp.Drawing.Processing
 
         /// <summary>
         /// Gets or sets a value indicating whether antialiasing should be applied.
-        /// Defaults to true.
+        /// <para/>
+        /// Defaults to <see cref="SixLabors.ImageSharp.Drawing.IntersectionRule.OddEven"/>.
         /// </summary>
         public IntersectionRule IntersectionRule { get; set; } = IntersectionRule.OddEven;
 

--- a/src/ImageSharp.Drawing/Processing/TextOptions.cs
+++ b/src/ImageSharp.Drawing/Processing/TextOptions.cs
@@ -40,12 +40,14 @@ namespace SixLabors.ImageSharp.Drawing.Processing
 
         /// <summary>
         /// Gets or sets a value indicating whether the text should be drawing with kerning enabled.
-        /// Defaults to true;
+        /// <para/>
+        /// Defaults to true.
         /// </summary>
         public bool ApplyKerning { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating the number of space widths a tab should lock to.
+        /// <para/>
         /// Defaults to 4.
         /// </summary>
         public float TabWidth
@@ -61,12 +63,14 @@ namespace SixLabors.ImageSharp.Drawing.Processing
 
         /// <summary>
         /// Gets or sets a value, if greater than 0, indicating the width at which text should wrap.
+        /// <para/>
         /// Defaults to 0.
         /// </summary>
         public float WrapTextWidth { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the DPI (Dots Per Inch) to render text along the X axis.
+        /// <para/>
         /// Defaults to 72.
         /// </summary>
         public float DpiX
@@ -82,6 +86,7 @@ namespace SixLabors.ImageSharp.Drawing.Processing
 
         /// <summary>
         /// Gets or sets a value indicating the DPI (Dots Per Inch) to render text along the Y axis.
+        /// <para/>
         /// Defaults to 72.
         /// </summary>
         public float DpiY
@@ -97,6 +102,7 @@ namespace SixLabors.ImageSharp.Drawing.Processing
 
         /// <summary>
         /// Gets or sets the line spacing. Applied as a multiple of the line height.
+        /// <para/>
         /// Defaults to 1.
         /// </summary>
         public float LineSpacing
@@ -115,24 +121,28 @@ namespace SixLabors.ImageSharp.Drawing.Processing
         /// If <see cref="WrapTextWidth"/> is greater than zero it will align relative to the space
         /// defined by the location and width, if <see cref="WrapTextWidth"/> equals zero, and thus
         /// wrapping disabled, then the alignment is relative to the drawing location.
-        /// Defaults to <see cref="HorizontalAlignment.Left"/>.
+        /// <para/>
+        /// Defaults to <see cref="SixLabors.Fonts.HorizontalAlignment.Left"/>.
         /// </summary>
         public HorizontalAlignment HorizontalAlignment { get; set; } = HorizontalAlignment.Left;
 
         /// <summary>
         /// Gets or sets a value indicating how to align the text relative to the rendering space.
-        /// Defaults to <see cref="VerticalAlignment.Top"/>.
+        /// <para/>
+        /// Defaults to <see cref="SixLabors.Fonts.VerticalAlignment.Top"/>.
         /// </summary>
         public VerticalAlignment VerticalAlignment { get; set; } = VerticalAlignment.Top;
 
         /// <summary>
         /// Gets the list of fallback font families to apply to the text drawing operation.
-        /// Defaults to <see cref="VerticalAlignment.Top"/>.
+        /// <para/>
+        /// Defaults to the empty list.
         /// </summary>
         public List<FontFamily> FallbackFonts { get; } = new List<FontFamily>();
 
         /// <summary>
         /// Gets or sets a value indicating whether we should render color(emoji) fonts.
+        /// <para/>
         /// Defaults to true.
         /// </summary>
         public bool RenderColorFonts { get; set; } = true;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [ ] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Some defaults value documentation were wrong. Also, `<para/>` was added to make the defaults stand out.

Before this pull request:
<img width="480" alt="Screenshot 2021-08-01 at 15 08 34" src="https://user-images.githubusercontent.com/51363/127772013-0706f53f-9276-4a93-88de-593d4c0b3586.png">

After this pull request:
<img width="480" alt="Screenshot 2021-08-01 at 15 08 46" src="https://user-images.githubusercontent.com/51363/127772018-90f3e020-2c0c-42ae-a6d6-c90f3d92183c.png">
