### PR TITLE
Update Fonts to use new API

### DIFF
--- a/samples/DrawShapesWithImageSharp/Program.cs
+++ b/samples/DrawShapesWithImageSharp/Program.cs
@@ -63,7 +63,7 @@ namespace SixLabors.Shapes.DrawShapesWithImageSharp
 
         private static void DrawText(string text)
         {
-            FontFamily fam = SystemFonts.Find("Arial");
+            FontFamily fam = SystemFonts.Get("Arial");
             var font = new Font(fam, 30);
             var style = new RendererOptions(font, 72);
             IPathCollection glyphs = TextBuilder.GenerateGlyphs(text, style);
@@ -73,7 +73,7 @@ namespace SixLabors.Shapes.DrawShapesWithImageSharp
 
         private static void DrawText(string text, IPath path)
         {
-            FontFamily fam = SystemFonts.Find("Arial");
+            FontFamily fam = SystemFonts.Get("Arial");
             var font = new Font(fam, 30);
             var style = new RendererOptions(font, 72)
             {

--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15.10" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
   </ItemGroup>
 

--- a/tests/ImageSharp.Drawing.Tests/Drawing/Text/DrawText.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/Text/DrawText.cs
@@ -24,7 +24,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing.Text
         public DrawText()
         {
             this.fontCollection = new FontCollection();
-            this.font = this.fontCollection.Install(TestFontUtilities.GetPath("SixLaborsSampleAB.woff")).CreateFont(12);
+            this.font = this.fontCollection.Add(TestFontUtilities.GetPath("SixLaborsSampleAB.woff")).CreateFont(12);
         }
 
         [Fact]

--- a/tests/ImageSharp.Drawing.Tests/Issues/Issue_46.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issue_46.cs
@@ -41,7 +41,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Issues
         {
             var fontCollection = new FontCollection();
             string fontPath = TestFontUtilities.GetPath(fontName);
-            return fontCollection.Install(fontPath).CreateFont(size);
+            return fontCollection.Add(fontPath).CreateFont(size);
         }
     }
 }

--- a/tests/ImageSharp.Drawing.Tests/Issues/Issue_54.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issue_54.cs
@@ -23,7 +23,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Issues
             // Creates a new image with empty pixel data.
             using (var image = new Image<Rgba32>(width, height))
             {
-                FontFamily family = SystemFonts.Find("verdana");
+                FontFamily family = SystemFonts.Get("verdana");
                 Font font = family.CreateFont(48, FontStyle.Bold);
 
                 // The options are optional

--- a/tests/ImageSharp.Drawing.Tests/TestFontUtilities.cs
+++ b/tests/ImageSharp.Drawing.Tests/TestFontUtilities.cs
@@ -32,7 +32,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests
         /// <param name="size">The font size.</param>
         /// <returns>The <see cref="Font"/></returns>
         public static Font GetFont(FontCollection collection, string name, float size)
-            => collection.Install(GetPath(name)).CreateFont(size);
+            => collection.Add(GetPath(name)).CreateFont(size);
 
         /// <summary>
         /// The formats directory.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Updates the Fonts ref to use the latest `FontCollection` API
<!-- Thanks for contributing to ImageSharp.Drawing! -->
