### PR TITLE
Add SolidBrush<TPixel> to paint a pixel value

### DIFF
--- a/src/ImageSharp.Drawing/Processing/SolidBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/SolidBrush.cs
@@ -34,98 +34,137 @@ namespace SixLabors.ImageSharp.Drawing.Processing
             RectangleF region)
             where TPixel : unmanaged, IPixel<TPixel>
             => new SolidBrushApplicator<TPixel>(configuration, options, source, this.Color.ToPixel<TPixel>());
+    }
+
+    /// <summary>
+    /// Provides an implementation of a solid brush for painting solid color areas.
+    /// </summary>
+    /// <typeparam name="TPixel">The pixel format of the color.</typeparam>
+    public sealed class SolidBrush<TPixel> : IBrush
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SolidBrush{TPixel}"/> class.
+        /// </summary>
+        /// <param name="color">The color.</param>
+        public SolidBrush(TPixel color) => this.Color = color;
 
         /// <summary>
-        /// The solid brush applicator.
+        /// Gets the color.
         /// </summary>
-        /// <typeparam name="TPixel">The pixel format.</typeparam>
-        private sealed class SolidBrushApplicator<TPixel> : BrushApplicator<TPixel>
-            where TPixel : unmanaged, IPixel<TPixel>
+        public TPixel Color { get; }
+
+        /// <inheritdoc />
+        public BrushApplicator<TImagePixel> CreateApplicator<TImagePixel>(
+            Configuration configuration,
+            GraphicsOptions options,
+            ImageFrame<TImagePixel> source,
+            RectangleF region)
+            where TImagePixel : unmanaged, IPixel<TImagePixel>
         {
-            private readonly IMemoryOwner<TPixel> colors;
-            private readonly MemoryAllocator allocator;
-            private readonly int scalineWidth;
-            private readonly ThreadLocalBlenderBuffers<TPixel> blenderBuffers;
-            private bool isDisposed;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="SolidBrushApplicator{TPixel}"/> class.
-            /// </summary>
-            /// <param name="configuration">The configuration instance to use when performing operations.</param>
-            /// <param name="options">The graphics options.</param>
-            /// <param name="source">The source image.</param>
-            /// <param name="color">The color.</param>
-            public SolidBrushApplicator(
-                Configuration configuration,
-                GraphicsOptions options,
-                ImageFrame<TPixel> source,
-                TPixel color)
-                : base(configuration, options, source)
+            if (this.Color is TImagePixel directColor)
             {
-                this.colors = configuration.MemoryAllocator.Allocate<TPixel>(source.Width);
-                this.colors.Memory.Span.Fill(color);
-                this.scalineWidth = source.Width;
-                this.allocator = configuration.MemoryAllocator;
+                return new SolidBrushApplicator<TImagePixel>(configuration, options, source, directColor);
+            }
+            else
+            {
+                var convertColor = default(TImagePixel);
+                convertColor.FromScaledVector4(this.Color.ToScaledVector4());
+                return new SolidBrushApplicator<TImagePixel>(configuration, options, source, convertColor);
+            }
+        }
+    }
 
-                // The threadlocal value is lazily invoked so there is no need to optionally create the type.
-                this.blenderBuffers = new ThreadLocalBlenderBuffers<TPixel>(configuration.MemoryAllocator, source.Width, true);
+    /// <summary>
+    /// The solid brush applicator.
+    /// </summary>
+    /// <typeparam name="TPixel">The pixel format.</typeparam>
+    internal sealed class SolidBrushApplicator<TPixel> : BrushApplicator<TPixel>
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        private readonly IMemoryOwner<TPixel> colors;
+        private readonly MemoryAllocator allocator;
+        private readonly int scalineWidth;
+        private readonly ThreadLocalBlenderBuffers<TPixel> blenderBuffers;
+        private bool isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SolidBrushApplicator{TPixel}"/> class.
+        /// </summary>
+        /// <param name="configuration">The configuration instance to use when performing operations.</param>
+        /// <param name="options">The graphics options.</param>
+        /// <param name="source">The source image.</param>
+        /// <param name="color">The color.</param>
+        public SolidBrushApplicator(
+            Configuration configuration,
+            GraphicsOptions options,
+            ImageFrame<TPixel> source,
+            TPixel color)
+            : base(configuration, options, source)
+        {
+            this.colors = configuration.MemoryAllocator.Allocate<TPixel>(source.Width);
+            this.colors.Memory.Span.Fill(color);
+            this.scalineWidth = source.Width;
+            this.allocator = configuration.MemoryAllocator;
+
+            // The threadlocal value is lazily invoked so there is no need to optionally create the type.
+            this.blenderBuffers = new ThreadLocalBlenderBuffers<TPixel>(configuration.MemoryAllocator, source.Width, true);
+        }
+
+        /// <inheritdoc />
+        public override void Apply(Span<float> scanline, int x, int y)
+        {
+            Span<TPixel> destinationRow = this.Target.GetPixelRowSpan(y).Slice(x);
+
+            // Constrain the spans to each other
+            if (destinationRow.Length > scanline.Length)
+            {
+                destinationRow = destinationRow.Slice(0, scanline.Length);
+            }
+            else
+            {
+                scanline = scanline.Slice(0, destinationRow.Length);
             }
 
-            /// <inheritdoc />
-            public override void Apply(Span<float> scanline, int x, int y)
+            Configuration configuration = this.Configuration;
+            if (this.Options.BlendPercentage == 1F)
             {
-                Span<TPixel> destinationRow = this.Target.GetPixelRowSpan(y).Slice(x);
+                // TODO: refactor the BlendPercentage == 1 logic to a separate, simpler BrushApplicator class.
+                this.Blender.Blend(configuration, destinationRow, destinationRow, this.colors.Memory.Span, scanline);
+            }
+            else
+            {
+                Span<float> amounts = this.blenderBuffers.AmountSpan.Slice(0, scanline.Length);
 
-                // Constrain the spans to each other
-                if (destinationRow.Length > scanline.Length)
+                for (int i = 0; i < scanline.Length; i++)
                 {
-                    destinationRow = destinationRow.Slice(0, scanline.Length);
-                }
-                else
-                {
-                    scanline = scanline.Slice(0, destinationRow.Length);
+                    amounts[i] = scanline[i] * this.Options.BlendPercentage;
                 }
 
-                Configuration configuration = this.Configuration;
-                if (this.Options.BlendPercentage == 1F)
-                {
-                    // TODO: refactor the BlendPercentage == 1 logic to a separate, simpler BrushApplicator class.
-                    this.Blender.Blend(configuration, destinationRow, destinationRow, this.colors.Memory.Span, scanline);
-                }
-                else
-                {
-                    Span<float> amounts = this.blenderBuffers.AmountSpan.Slice(0, scanline.Length);
+                this.Blender.Blend(
+                    configuration,
+                    destinationRow,
+                    destinationRow,
+                    this.colors.Memory.Span,
+                    amounts);
+            }
+        }
 
-                    for (int i = 0; i < scanline.Length; i++)
-                    {
-                        amounts[i] = scanline[i] * this.Options.BlendPercentage;
-                    }
-
-                    this.Blender.Blend(
-                        configuration,
-                        destinationRow,
-                        destinationRow,
-                        this.colors.Memory.Span,
-                        amounts);
-                }
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (this.isDisposed)
+            {
+                return;
             }
 
-            /// <inheritdoc />
-            protected override void Dispose(bool disposing)
+            if (disposing)
             {
-                if (this.isDisposed)
-                {
-                    return;
-                }
-
-                if (disposing)
-                {
-                    this.colors.Dispose();
-                    this.blenderBuffers.Dispose();
-                }
-
-                this.isDisposed = true;
+                this.colors.Dispose();
+                this.blenderBuffers.Dispose();
             }
+
+            this.isDisposed = true;
         }
     }
 }

--- a/tests/ImageSharp.Drawing.Tests/Drawing/ClearSolidBrushTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/ClearSolidBrushTests.cs
@@ -49,6 +49,22 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
         }
 
         [Theory]
+        [WithBlankImage(16, 16, PixelTypes.RgbaVector)]
+        public void WorksAtHighPrecision<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using (var image = provider.GetImage() as Image<RgbaVector>)
+            {
+                var pixel = new RgbaVector(1e-38f, 2e-38f, 3e-38f);
+                var brush = new SolidBrush<RgbaVector>(pixel);
+                image.Mutate(c => c.Clear(brush));
+
+                image.DebugSave(provider, appendSourceFileOrDescription: false);
+                image.ComparePixelBufferTo(pixel);
+            }
+        }
+
+        [Theory]
         [WithSolidFilledImages(16, 16, "Red", PixelTypes.Rgba32, "Blue")]
         [WithSolidFilledImages(16, 16, "Yellow", PixelTypes.Rgba32, "Khaki")]
         public void WhenColorIsOpaque_OverridePreviousColor<TPixel>(

--- a/tests/ImageSharp.Drawing.Tests/Drawing/FillSolidBrushTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/FillSolidBrushTests.cs
@@ -48,6 +48,22 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
         }
 
         [Theory]
+        [WithBlankImage(16, 16, PixelTypes.RgbaVector)]
+        public void WorksAtHighPrecision<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            using (var image = provider.GetImage() as Image<RgbaVector>)
+            {
+                var pixel = new RgbaVector(1e-38f, 2e-38f, 3e-38f);
+                var brush = new SolidBrush<RgbaVector>(pixel);
+                image.Mutate(c => c.Fill(brush));
+
+                image.DebugSave(provider, appendSourceFileOrDescription: false);
+                image.ComparePixelBufferTo(pixel);
+            }
+        }
+
+        [Theory]
         [WithSolidFilledImages(16, 16, "Red", PixelTypes.Rgba32, "Blue")]
         [WithSolidFilledImages(16, 16, "Yellow", PixelTypes.Rgba32, "Khaki")]
         public void WhenColorIsOpaque_OverridePreviousColor<TPixel>(


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [X] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [X] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Implemented a variation of `SolidBrush` that takes color as `TPixel` rather than `Color`.  This allows for painting that uses full precision of `RgbaVector` and other floating-point pixel formats.

<!-- Thanks for contributing to ImageSharp.Drawing! -->
