### PR TITLE
Add wordbreaking support

### DIFF
--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15.10" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15.15" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
   </ItemGroup>
 

--- a/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
@@ -57,6 +57,7 @@ namespace SixLabors.ImageSharp.Drawing.Processing.Processors.Text
                 LineSpacing = this.Options.TextOptions.LineSpacing,
                 FallbackFontFamilies = this.Options.TextOptions.FallbackFonts,
                 ColorFontSupport = this.definition.Options.TextOptions.RenderColorFonts ? ColorFontSupport.MicrosoftColrFormat : ColorFontSupport.None,
+                WordBreaking = this.definition.Options.TextOptions.WordBreaking
             };
 
             this.textRenderer = new CachingGlyphRenderer(

--- a/src/ImageSharp.Drawing/Processing/TextOptions.cs
+++ b/src/ImageSharp.Drawing/Processing/TextOptions.cs
@@ -122,16 +122,23 @@ namespace SixLabors.ImageSharp.Drawing.Processing
         /// defined by the location and width, if <see cref="WrapTextWidth"/> equals zero, and thus
         /// wrapping disabled, then the alignment is relative to the drawing location.
         /// <para/>
-        /// Defaults to <see cref="SixLabors.Fonts.HorizontalAlignment.Left"/>.
+        /// Defaults to <see cref="HorizontalAlignment.Left"/>.
         /// </summary>
         public HorizontalAlignment HorizontalAlignment { get; set; } = HorizontalAlignment.Left;
 
         /// <summary>
         /// Gets or sets a value indicating how to align the text relative to the rendering space.
         /// <para/>
-        /// Defaults to <see cref="SixLabors.Fonts.VerticalAlignment.Top"/>.
+        /// Defaults to <see cref="VerticalAlignment.Top"/>.
         /// </summary>
         public VerticalAlignment VerticalAlignment { get; set; } = VerticalAlignment.Top;
+
+        /// <summary>
+        /// Gets or sets a value indicating what word breaking mode to use when wrapping text.
+        /// <para/>
+        /// Defaults to <see cref="WordBreaking.Normal"/>.
+        /// </summary>
+        public WordBreaking WordBreaking { get; set; } = WordBreaking.Normal;
 
         /// <summary>
         /// Gets the list of fallback font families to apply to the text drawing operation.

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectly_WithLineSpacing_linespacing_1.5_linecount_3_wrap_True.png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectly_WithLineSpacing_linespacing_1.5_linecount_3_wrap_True.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a46ab8c2e668526690447fd3ef39191c7d23b7a1277110a0ebde93d6c9fc1cbd
-size 27014
+oid sha256:29f0e3f843e2041e1746e17cb5866d99877ecc00da38a641a52b9e2c2a41b8f4
+size 27017

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectly_WithLineSpacing_linespacing_1_linecount_5_wrap_True.png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectly_WithLineSpacing_linespacing_1_linecount_5_wrap_True.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2f8ae895b7e85cbff8755c95a387c231b072b61ae6af1f09566e90e8a2075a0
-size 38752
+oid sha256:4ce8ecf2512f564a3120132d15a4f51d31339f6035dfef17602c0819fd469427
+size 38746

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectly_WithLineSpacing_linespacing_2_linecount_2_wrap_True.png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectly_WithLineSpacing_linespacing_2_linecount_2_wrap_True.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f30f07793250befc4c44a5ce8c117d78a2e4ee01af9e2658d134a1a8708d694f
-size 19483
+oid sha256:f449344320fea4cee5f7ec780c8894c8192d5be7cb5d078ce7f5801078219cde
+size 19493


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Bumps the underlying fonts version so we can use the new word breaking options.
<!-- Thanks for contributing to ImageSharp.Drawing! -->
