### PR TITLE
Remove double origin assignment from TextBuilder

### DIFF
--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15.20" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta15.23" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0-alpha.0.123" />
   </ItemGroup>
 
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />

--- a/src/ImageSharp.Drawing/Shapes/Text/TextBuilder.cs
+++ b/src/ImageSharp.Drawing/Shapes/Text/TextBuilder.cs
@@ -19,7 +19,7 @@ namespace SixLabors.ImageSharp.Drawing
         /// <returns>The <see cref="IPathCollection"/></returns>
         public static IPathCollection GenerateGlyphs(string text, TextOptions textOptions)
         {
-            GlyphBuilder glyphBuilder = new(textOptions.Origin);
+            GlyphBuilder glyphBuilder = new();
             TextRenderer renderer = new(glyphBuilder);
 
             renderer.RenderText(text, textOptions);

--- a/tests/ImageSharp.Drawing.Tests/ConfigurationTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/ConfigurationTests.cs
@@ -20,7 +20,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests
 
         public Configuration DefaultConfiguration { get; }
 
-        private readonly int expectedDefaultConfigurationCount = 5;
+        private readonly int expectedDefaultConfigurationCount = 7;
 
         public ConfigurationTests()
         {

--- a/tests/ImageSharp.Drawing.Tests/Shapes/TextBuilderTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/TextBuilderTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Numerics;
+using SixLabors.Fonts;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Drawing.Tests.Shapes
+{
+    public class TextBuilderTests
+    {
+        [Fact]
+        public void TextBuilder_Bounds_AreCorrect()
+        {
+            Vector2 position = new(5, 5);
+            var options = new TextOptions(TestFontUtilities.GetFont(TestFonts.OpenSans, 16))
+            {
+                Origin = position
+            };
+
+            string text = "Hello World";
+
+            IPathCollection glyphs = TextBuilder.GenerateGlyphs(text, options);
+
+            RectangleF builderBounds = glyphs.Bounds;
+            FontRectangle measuredBounds = TextMeasurer.MeasureBounds(text, options);
+
+            Assert.Equal(measuredBounds.X, builderBounds.X);
+            Assert.Equal(measuredBounds.Y, builderBounds.Y);
+            Assert.Equal(measuredBounds.Width, builderBounds.Width);
+            Assert.Equal(measuredBounds.Height, builderBounds.Height);
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Drawing text via `TextBuilder` was incorrectly double offsetting the input if the `TextOptions` contained an origin when compared to `DrawText`.

I've also updated our refs to the latest MyGet builds to ensure we are testing against recent changes.
CC @Turnerj 
<!-- Thanks for contributing to ImageSharp.Drawing! -->
