### PR TITLE
Prevent a subpixel being able to reset dirty flag

### DIFF
--- a/src/ImageSharp.Drawing/Shapes/Rasterization/RasterizerExtensions.cs
+++ b/src/ImageSharp.Drawing/Shapes/Rasterization/RasterizerExtensions.cs
@@ -45,7 +45,7 @@ namespace SixLabors.ImageSharp.Drawing.Shapes.Rasterization
                     float subpixelWidth = (startX + 1 - scanStart) / scanner.SubpixelDistance;
 
                     scanline[startX] += subpixelWidth * scanner.SubpixelArea;
-                    scanlineDirty = subpixelWidth > 0;
+                    scanlineDirty |= subpixelWidth > 0;
                 }
 
                 if (endX >= 0 && endX < scanline.Length)
@@ -54,7 +54,7 @@ namespace SixLabors.ImageSharp.Drawing.Shapes.Rasterization
                     float subpixelWidth = (scanEnd - endX) / scanner.SubpixelDistance;
 
                     scanline[endX] += subpixelWidth * scanner.SubpixelArea;
-                    scanlineDirty = subpixelWidth > 0;
+                    scanlineDirty |= subpixelWidth > 0;
                 }
 
                 int nextX = startX + 1;

--- a/tests/ImageSharp.Drawing.Tests/Shapes/Scan/RasterizerExtensionsTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/Scan/RasterizerExtensionsTests.cs
@@ -44,9 +44,6 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Shapes.Scan
             };
 
             var comparer = ImageComparer.TolerantPercentage(0.001f);
-#if !NETCOREAPP
-            comparer = ImageComparer.TolerantPercentage(0.002f);
-#endif
             provider.RunValidatingProcessorTest(
                 x => x
                  .SetGraphicsOptions(o => o.Antialias = false)

--- a/tests/ImageSharp.Drawing.Tests/Shapes/Scan/RasterizerExtensionsTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/Scan/RasterizerExtensionsTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Drawing.Shapes.Rasterization;
+using SixLabors.ImageSharp.Drawing.Tests.TestUtilities.ImageComparison;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Drawing.Tests.Shapes.Scan
+{
+    public class RasterizerExtensionsTests
+    {
+        [Fact]
+        public void DoesNotOverwriteIsDirtyFlagWhenOnlyFillingSubpixels()
+        {
+            var scanner = PolygonScanner.Create(new RectangularPolygon(0.3f, 0.2f, 0.7f, 1.423f), 0, 20, 1, IntersectionRule.OddEven, MemoryAllocator.Default);
+
+            float[] buffer = new float[12];
+
+            scanner.MoveToNextPixelLine(); // offset
+
+            bool isDirty = scanner.ScanCurrentPixelLineInto(0, 0, buffer.AsSpan());
+
+            Assert.True(isDirty);
+        }
+
+        [Theory]
+        [WithSolidFilledImages(400, 75, "White", PixelTypes.Rgba32)]
+        public void AntialiasingIsAntialiased<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            Font font36 = TestFontUtilities.GetFont(TestFonts.OpenSans, 20);
+            var textOpt = new TextOptions(font36)
+            {
+                Dpi = 96,
+                Origin = new PointF(0, 0)
+            };
+
+            provider.RunValidatingProcessorTest(x => x
+                 .SetGraphicsOptions(o => o.Antialias = false)
+                 .DrawText(textOpt, "Hello, World!", Color.Black));
+        }
+    }
+}

--- a/tests/ImageSharp.Drawing.Tests/Shapes/Scan/RasterizerExtensionsTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/Scan/RasterizerExtensionsTests.cs
@@ -43,9 +43,15 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Shapes.Scan
                 Origin = new PointF(0, 0)
             };
 
-            provider.RunValidatingProcessorTest(x => x
+            var comparer = ImageComparer.TolerantPercentage(0.001f);
+#if !NETCOREAPP
+            comparer = ImageComparer.TolerantPercentage(0.002f);
+#endif
+            provider.RunValidatingProcessorTest(
+                x => x
                  .SetGraphicsOptions(o => o.Antialias = false)
-                 .DrawText(textOpt, "Hello, World!", Color.Black));
+                 .DrawText(textOpt, "Hello, World!", Color.Black),
+                comparer: comparer);
         }
     }
 }

--- a/tests/Images/ReferenceOutput/Drawing/FillPolygonTests/Fill_RectangularPolygon_Solid_TransformedUsingConfiguration_Rgba32_BasicTestPattern100x100.png
+++ b/tests/Images/ReferenceOutput/Drawing/FillPolygonTests/Fill_RectangularPolygon_Solid_TransformedUsingConfiguration_Rgba32_BasicTestPattern100x100.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8f3c05544c5a2f9fa547ba7effe072a78d89d865daf610ff98ecdfad46aced47
-size 976
+oid sha256:ac009c65fec2d076e997491a1f8f2158e63959dd9fb2ecf575b88baba2829eb5
+size 606

--- a/tests/Images/ReferenceOutput/Drawing/FillPolygonTests/Fill_RectangularPolygon_Solid_Transformed_Rgba32_BasicTestPattern100x100.png
+++ b/tests/Images/ReferenceOutput/Drawing/FillPolygonTests/Fill_RectangularPolygon_Solid_Transformed_Rgba32_BasicTestPattern100x100.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8f3c05544c5a2f9fa547ba7effe072a78d89d865daf610ff98ecdfad46aced47
-size 976
+oid sha256:ac009c65fec2d076e997491a1f8f2158e63959dd9fb2ecf575b88baba2829eb5
+size 606

--- a/tests/Images/ReferenceOutput/RasterizerExtensionsTests/AntialiasingIsAntialiased_Rgba32_Solid400x75_(255,255,255,255).png
+++ b/tests/Images/ReferenceOutput/RasterizerExtensionsTests/AntialiasingIsAntialiased_Rgba32_Solid400x75_(255,255,255,255).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:faf333e523c0f07132aceeb9a4464fdf69c4382824b25b24a8adcc17290dd549
+size 1212


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

When rasterizing scanlines where the intersection with the region (any where on the line) is less than a pixel wide we had a bug that would reset the `scanlineDirty`. it should only ever be possible to flip the bit to true and never false in the region of changed code.

How this ended up manifesting is when drawing a shape (seen usually in text) of a pixel wide you would see antialias artefacts even with it disabled.

Before
![image](https://user-images.githubusercontent.com/166440/155492114-dedde701-8bc2-40ba-9ee9-76c50e8dc34a.png)
After
![image](https://user-images.githubusercontent.com/166440/155492142-369df29e-9106-4fb8-a1aa-b74909f3c928.png)


resolves #203
