### PR TITLE
Track memory allocations in tests

### DIFF
--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <AssemblyName>SixLabors.ImageSharp.Drawing</AssemblyName>
     <AssemblyTitle>SixLabors.ImageSharp.Drawing</AssemblyTitle>
@@ -14,16 +13,12 @@
     <Description>An extension to ImageSharp that allows the drawing of images, paths, and text.</Description>
     <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\..\shared-infrastructure\branding\icons\imagesharp.drawing\sixlabors.imagesharp.drawing.128.png" Pack="true" PackagePath="" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta16" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.1-alpha.0.1" />
   </ItemGroup>
-
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />
-
 </Project>

--- a/src/ImageSharp.Drawing/Shapes/Rasterization/PolygonScanner.cs
+++ b/src/ImageSharp.Drawing/Shapes/Rasterization/PolygonScanner.cs
@@ -98,7 +98,7 @@ namespace SixLabors.ImageSharp.Drawing.Shapes.Rasterization
             IntersectionRule intersectionRule,
             MemoryAllocator allocator)
         {
-            var multipolygon = TessellatedMultipolygon.Create(polygon, allocator);
+            using var multipolygon = TessellatedMultipolygon.Create(polygon, allocator);
             var edges = ScanEdgeCollection.Create(multipolygon, allocator, subsampling);
             var scanner = new PolygonScanner(edges, multipolygon.TotalVertexCount * 2, minY, maxY, subsampling, intersectionRule, allocator);
             scanner.Init();

--- a/src/ImageSharp.Drawing/Shapes/Rasterization/ScanEdgeCollection.cs
+++ b/src/ImageSharp.Drawing/Shapes/Rasterization/ScanEdgeCollection.cs
@@ -40,7 +40,7 @@ namespace SixLabors.ImageSharp.Drawing.Shapes.Rasterization
             MemoryAllocator allocator,
             int subsampling)
         {
-            TessellatedMultipolygon multipolygon = TessellatedMultipolygon.Create(polygon, allocator);
+            using TessellatedMultipolygon multipolygon = TessellatedMultipolygon.Create(polygon, allocator);
             return Create(multipolygon, allocator, subsampling);
         }
     }

--- a/tests/ImageSharp.Drawing.Tests/Drawing/Text/DrawTextOnImageTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/Text/DrawTextOnImageTests.cs
@@ -16,6 +16,7 @@ using Xunit.Abstractions;
 namespace SixLabors.ImageSharp.Drawing.Tests.Drawing.Text
 {
     [GroupOutput("Drawing/Text")]
+    [ValidateDisposedMemoryAllocations]
     public class DrawTextOnImageTests
     {
         private const string AB = "AB\nAB";

--- a/tests/ImageSharp.Drawing.Tests/MemoryAllocatorValidator.cs
+++ b/tests/ImageSharp.Drawing.Tests/MemoryAllocatorValidator.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using SixLabors.ImageSharp.Diagnostics;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Drawing.Tests
+{
+    public static class MemoryAllocatorValidator
+    {
+        private static List<string> traces = new List<string>();
+
+        public static void MonitorStackTraces() => MemoryDiagnostics.UndisposedAllocation += MemoryDiagnostics_UndisposedAllocation;
+
+        public static List<string> GetStackTraces()
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            return traces;
+        }
+
+        private static void MemoryDiagnostics_UndisposedAllocation(string allocationStackTrace)
+        {
+            lock (traces)
+            {
+                traces.Add(allocationStackTrace);
+            }
+        }
+
+        public static TestMemoryAllocatorDisposable MonitorAllocations()
+        {
+            MemoryDiagnostics.Current = new();
+            return new TestMemoryAllocatorDisposable();
+        }
+
+        public static void StopMonitoringAllocations() => MemoryDiagnostics.Current = null;
+
+        public static void ValidateAllocation(int max = 0)
+        {
+            var count = MemoryDiagnostics.TotalUndisposedAllocationCount;
+
+            var pass = count <= max;
+            Assert.True(pass, $"Expected a max of {max} undisposed buffers but found {count}");
+
+            if (count > 0)
+            {
+                Debug.WriteLine("We should have Zero undisposed memory allocations.");
+            }
+        }
+
+        public struct TestMemoryAllocatorDisposable : IDisposable
+        {
+            public void Dispose()
+                => StopMonitoringAllocations();
+
+            public void Validate(int maxAllocations = 0)
+                => ValidateAllocation(maxAllocations);
+        }
+    }
+}

--- a/tests/ImageSharp.Drawing.Tests/Shapes/Scan/ScanEdgeCollectionTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/Scan/ScanEdgeCollectionTests.cs
@@ -10,13 +10,12 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Shapes.Scan
 {
     public class ScanEdgeCollectionTests
     {
-        private ScanEdgeCollection edges;
-
         private static MemoryAllocator MemoryAllocator => Configuration.Default.MemoryAllocator;
 
         private static readonly DebugDraw DebugDraw = new DebugDraw(nameof(ScanEdgeCollectionTests));
 
         private void VerifyEdge(
+            ScanEdgeCollection edges,
             float y0,
             float y1,
             (FuzzyFloat X, FuzzyFloat Y) arbitraryPoint,
@@ -24,7 +23,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Shapes.Scan
             int emit1,
             bool edgeUp)
         {
-            foreach (ScanEdge e in this.edges.Edges)
+            foreach (ScanEdge e in edges.Edges)
             {
                 if (y0 == e.Y0 && y1 == e.Y1)
                 {
@@ -45,6 +44,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Shapes.Scan
         }
 
         [Fact]
+        [ValidateDisposedMemoryAllocations]
         public void SimplePolygon_AllEmitCases()
         {
             // see: SimplePolygon_AllEmitCases.png
@@ -78,29 +78,29 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Shapes.Scan
 
             DebugDraw.Polygon(polygon, 1, 100);
 
-            this.edges = ScanEdgeCollection.Create(polygon, MemoryAllocator, 16);
+            using var edges = ScanEdgeCollection.Create(polygon, MemoryAllocator, 16);
 
-            Assert.Equal(19, this.edges.Edges.Length);
+            Assert.Equal(19, edges.Edges.Length);
 
-            this.VerifyEdge(1f, 2f, (2.5f, 1.5f), 1, 2, true);
-            this.VerifyEdge(1f, 3f, (3.5f, 2f), 1, 1, false);
-            this.VerifyEdge(1f, 3f, (5f, 2f), 1, 1, true);
-            this.VerifyEdge(1f, 2f, (6.5f, 1.5f), 1, 2, false);
-            this.VerifyEdge(2f, 3f, (8.5f, 2.5f), 1, 0, false);
-            this.VerifyEdge(3f, 4f, (9f, 3.5f), 1, 0, false);
-            this.VerifyEdge(4f, 5f, (9.5f, 4.5f), 1, 0, false);
-            this.VerifyEdge(5f, 6f, (9.5f, 5.5f), 1, 1, false);
-            this.VerifyEdge(6f, 7f, (8f, 6.5f), 2, 2, false);
-            this.VerifyEdge(7f, 8f, (9f, 7.5f), 1, 1, false);
-            this.VerifyEdge(7f, 8f, (6.5f, 7.5f), 1, 1, true);
-            this.VerifyEdge(7f, 8f, (5.5f, 7.5f), 1, 1, false);
-            this.VerifyEdge(7f, 8f, (4.5f, 7.5f), 1, 1, true);
-            this.VerifyEdge(7f, 8f, (3.5f, 7.5f), 1, 1, false);
-            this.VerifyEdge(6f, 8f, (2f, 7f), 0, 1, true);
-            this.VerifyEdge(5f, 6f, (2.5f, 5.5f), 2, 1, true);
-            this.VerifyEdge(4f, 5f, (2f, 4.5f), 0, 1, true);
-            this.VerifyEdge(3f, 4f, (1.5f, 3.5f), 0, 1, true);
-            this.VerifyEdge(2f, 3f, (1f, 1.5f), 1, 1, true);
+            this.VerifyEdge(edges, 1f, 2f, (2.5f, 1.5f), 1, 2, true);
+            this.VerifyEdge(edges, 1f, 3f, (3.5f, 2f), 1, 1, false);
+            this.VerifyEdge(edges, 1f, 3f, (5f, 2f), 1, 1, true);
+            this.VerifyEdge(edges, 1f, 2f, (6.5f, 1.5f), 1, 2, false);
+            this.VerifyEdge(edges, 2f, 3f, (8.5f, 2.5f), 1, 0, false);
+            this.VerifyEdge(edges, 3f, 4f, (9f, 3.5f), 1, 0, false);
+            this.VerifyEdge(edges, 4f, 5f, (9.5f, 4.5f), 1, 0, false);
+            this.VerifyEdge(edges, 5f, 6f, (9.5f, 5.5f), 1, 1, false);
+            this.VerifyEdge(edges, 6f, 7f, (8f, 6.5f), 2, 2, false);
+            this.VerifyEdge(edges, 7f, 8f, (9f, 7.5f), 1, 1, false);
+            this.VerifyEdge(edges, 7f, 8f, (6.5f, 7.5f), 1, 1, true);
+            this.VerifyEdge(edges, 7f, 8f, (5.5f, 7.5f), 1, 1, false);
+            this.VerifyEdge(edges, 7f, 8f, (4.5f, 7.5f), 1, 1, true);
+            this.VerifyEdge(edges, 7f, 8f, (3.5f, 7.5f), 1, 1, false);
+            this.VerifyEdge(edges, 6f, 8f, (2f, 7f), 0, 1, true);
+            this.VerifyEdge(edges, 5f, 6f, (2.5f, 5.5f), 2, 1, true);
+            this.VerifyEdge(edges, 4f, 5f, (2f, 4.5f), 0, 1, true);
+            this.VerifyEdge(edges, 3f, 4f, (1.5f, 3.5f), 0, 1, true);
+            this.VerifyEdge(edges, 2f, 3f, (1f, 1.5f), 1, 1, true);
         }
 
         [Fact]
@@ -114,39 +114,39 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Shapes.Scan
             IPath polygon = contour.Clip(hole);
             DebugDraw.Polygon(polygon, 1, 100);
 
-            this.edges = ScanEdgeCollection.Create(polygon, MemoryAllocator, 16);
+            using var edges = ScanEdgeCollection.Create(polygon, MemoryAllocator, 16);
 
-            Assert.Equal(8, this.edges.Count);
+            Assert.Equal(8, edges.Count);
 
-            this.VerifyEdge(1, 4, (1, 2), 1, 1, true);
-            this.VerifyEdge(1, 2, (4, 1.5f), 1, 2, false);
-            this.VerifyEdge(4, 5, (2, 4.5f), 2, 1, true);
-            this.VerifyEdge(2, 5, (5, 3f), 1, 1, false);
+            this.VerifyEdge(edges, 1, 4, (1, 2), 1, 1, true);
+            this.VerifyEdge(edges, 1, 2, (4, 1.5f), 1, 2, false);
+            this.VerifyEdge(edges, 4, 5, (2, 4.5f), 2, 1, true);
+            this.VerifyEdge(edges, 2, 5, (5, 3f), 1, 1, false);
 
-            this.VerifyEdge(2, 3, (2, 2.5f), 2, 2, false);
-            this.VerifyEdge(2, 3, (3.5f, 2.5f), 2, 1, true);
-            this.VerifyEdge(3, 4, (3, 3.5f), 1, 2, false);
-            this.VerifyEdge(3, 4, (4, 3.5f), 0, 2, true);
+            this.VerifyEdge(edges, 2, 3, (2, 2.5f), 2, 2, false);
+            this.VerifyEdge(edges, 2, 3, (3.5f, 2.5f), 2, 1, true);
+            this.VerifyEdge(edges, 3, 4, (3, 3.5f), 1, 2, false);
+            this.VerifyEdge(edges, 3, 4, (4, 3.5f), 0, 2, true);
         }
 
         [Fact]
         public void NumericCornerCase_C()
         {
-            this.edges = ScanEdgeCollection.Create(NumericCornerCasePolygons.C, MemoryAllocator, 4);
-            Assert.Equal(2, this.edges.Count);
-            this.VerifyEdge(3.5f, 4f, (2f, 3.75f), 1, 1, true);
-            this.VerifyEdge(3.5f, 4f, (8f, 3.75f), 1, 1, false);
+            using var edges = ScanEdgeCollection.Create(NumericCornerCasePolygons.C, MemoryAllocator, 4);
+            Assert.Equal(2, edges.Count);
+            this.VerifyEdge(edges, 3.5f, 4f, (2f, 3.75f), 1, 1, true);
+            this.VerifyEdge(edges, 3.5f, 4f, (8f, 3.75f), 1, 1, false);
         }
 
         [Fact]
         public void NumericCornerCase_D()
         {
-            this.edges = ScanEdgeCollection.Create(NumericCornerCasePolygons.D, MemoryAllocator, 4);
-            Assert.Equal(5, this.edges.Count);
+            using var edges = ScanEdgeCollection.Create(NumericCornerCasePolygons.D, MemoryAllocator, 4);
+            Assert.Equal(5, edges.Count);
 
-            this.VerifyEdge(3.25f, 4f, (12f, 3.75f), 1, 1, true);
-            this.VerifyEdge(3.25f, 3.5f, (15f, 3.375f), 1, 0, false);
-            this.VerifyEdge(3.5f, 4f, (18f, 3.75f), 1, 1, false);
+            this.VerifyEdge(edges, 3.25f, 4f, (12f, 3.75f), 1, 1, true);
+            this.VerifyEdge(edges, 3.25f, 3.5f, (15f, 3.375f), 1, 0, false);
+            this.VerifyEdge(edges, 3.5f, 4f, (18f, 3.75f), 1, 1, false);
 
             // TODO: verify 2 more edges
         }
@@ -154,14 +154,14 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Shapes.Scan
         [Fact]
         public void NumericCornerCase_H_ShouldCollapseNearZeroEdge()
         {
-            this.edges = ScanEdgeCollection.Create(NumericCornerCasePolygons.H, MemoryAllocator, 4);
+            using var edges = ScanEdgeCollection.Create(NumericCornerCasePolygons.H, MemoryAllocator, 4);
 
-            Assert.Equal(3, this.edges.Count);
-            this.VerifyEdge(1.75f, 2f, (15f, 1.875f), 1, 1, true);
-            this.VerifyEdge(1.75f, 2.25f, (16f, 2f), 1, 1, false);
+            Assert.Equal(3, edges.Count);
+            this.VerifyEdge(edges, 1.75f, 2f, (15f, 1.875f), 1, 1, true);
+            this.VerifyEdge(edges, 1.75f, 2.25f, (16f, 2f), 1, 1, false);
 
             // this places two dummy points:
-            this.VerifyEdge(2f, 2.25f, (15f, 2.125f), 2, 1, true);
+            this.VerifyEdge(edges, 2f, 2.25f, (15f, 2.125f), 2, 1, true);
         }
 
         private static FuzzyFloat F(float value, float eps) => new FuzzyFloat(value, eps);

--- a/tests/ImageSharp.Drawing.Tests/TestFormat.cs
+++ b/tests/ImageSharp.Drawing.Tests/TestFormat.cs
@@ -199,7 +199,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests
 
             public int HeaderSize => this.testFormat.HeaderSize;
 
-            public Image<TPixel> Decode<TPixel>(Configuration config, Stream stream)
+            public Image<TPixel> Decode<TPixel>(Configuration config, Stream stream, CancellationToken cancellationToken)
                 where TPixel : unmanaged, IPixel<TPixel>
             {
                 var ms = new MemoryStream();
@@ -218,7 +218,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests
 
             public bool IsSupportedFileFormat(Span<byte> header) => this.testFormat.IsSupportedFileFormat(header);
 
-            public Image Decode(Configuration configuration, Stream stream) => this.Decode<TestPixelForAgnosticDecode>(configuration, stream);
+            public Image Decode(Configuration configuration, Stream stream, CancellationToken cancellationToken) => this.Decode<TestPixelForAgnosticDecode>(configuration, stream, cancellationToken);
 
             public Task<Image<TPixel>> DecodeAsync<TPixel>(Configuration configuration, Stream stream, CancellationToken cancellationToken)
                 where TPixel : unmanaged, IPixel<TPixel>

--- a/tests/ImageSharp.Drawing.Tests/TestUtilities/ImageProviders/FileProvider.cs
+++ b/tests/ImageSharp.Drawing.Tests/TestUtilities/ImageProviders/FileProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
+using SixLabors.ImageSharp.Diagnostics;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.PixelFormats;
 

--- a/tests/ImageSharp.Drawing.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
+++ b/tests/ImageSharp.Drawing.Tests/TestUtilities/ReferenceCodecs/MagickReferenceDecoder.cs
@@ -61,9 +61,9 @@ namespace SixLabors.ImageSharp.Drawing.Tests.TestUtilities.ReferenceCodecs
 
         public Task<Image<TPixel>> DecodeAsync<TPixel>(Configuration configuration, Stream stream, CancellationToken cancellationToken)
             where TPixel : unmanaged, PixelFormats.IPixel<TPixel>
-            => Task.FromResult(this.Decode<TPixel>(configuration, stream));
+            => Task.FromResult(this.Decode<TPixel>(configuration, stream, cancellationToken));
 
-        public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
+        public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream, CancellationToken cancellationToken)
             where TPixel : unmanaged, PixelFormats.IPixel<TPixel>
         {
             var bmpReadDefines = new BmpReadDefines
@@ -105,7 +105,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.TestUtilities.ReferenceCodecs
             return new Image<TPixel>(configuration, new ImageMetadata(), framesList);
         }
 
-        public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
+        public Image Decode(Configuration configuration, Stream stream, CancellationToken cancellationToken) => this.Decode<Rgba32>(configuration, stream, cancellationToken);
 
         public async Task<Image> DecodeAsync(Configuration configuration, Stream stream, CancellationToken cancellationToken)
             => await this.DecodeAsync<Rgba32>(configuration, stream, cancellationToken);

--- a/tests/ImageSharp.Drawing.Tests/TestUtilities/ReferenceCodecs/SystemDrawingReferenceDecoder.cs
+++ b/tests/ImageSharp.Drawing.Tests/TestUtilities/ReferenceCodecs/SystemDrawingReferenceDecoder.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.TestUtilities.ReferenceCodecs
     {
         public static SystemDrawingReferenceDecoder Instance { get; } = new SystemDrawingReferenceDecoder();
 
-        public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
+        public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream, CancellationToken cancellationToken)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             using (var sourceBitmap = new System.Drawing.Bitmap(stream))
@@ -44,7 +44,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.TestUtilities.ReferenceCodecs
             }
         }
 
-        public IImageInfo Identify(Configuration configuration, Stream stream)
+        public IImageInfo Identify(Configuration configuration, Stream stream, CancellationToken cancellationToken)
         {
             using (var sourceBitmap = new System.Drawing.Bitmap(stream))
             {
@@ -56,8 +56,8 @@ namespace SixLabors.ImageSharp.Drawing.Tests.TestUtilities.ReferenceCodecs
         public Task<IImageInfo> IdentifyAsync(Configuration configuration, Stream stream, CancellationToken cancellationToken)
             => throw new System.NotImplementedException();
 
-        public Image Decode(Configuration configuration, Stream stream)
-            => this.Decode<Rgba32>(configuration, stream);
+        public Image Decode(Configuration configuration, Stream stream, CancellationToken cancellationToken)
+            => this.Decode<Rgba32>(configuration, stream, cancellationToken);
 
         public Task<Image<TPixel>> DecodeAsync<TPixel>(Configuration configuration, Stream stream, CancellationToken cancellationToken)
             where TPixel : unmanaged, IPixel<TPixel>

--- a/tests/ImageSharp.Drawing.Tests/TestUtilities/Tests/TestImageProviderTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/TestUtilities/Tests/TestImageProviderTests.cs
@@ -350,7 +350,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests
                 }
             }
 
-            public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
+            public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream, CancellationToken cancellationToken)
                 where TPixel : unmanaged, IPixel<TPixel>
             {
                 InvocationCounts[this.callerName]++;
@@ -365,7 +365,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests
                 InvocationCounts[name] = 0;
             }
 
-            public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
+            public Image Decode(Configuration configuration, Stream stream, CancellationToken cancellationToken) => this.Decode<Rgba32>(configuration, stream, cancellationToken);
 
             public Task<Image<TPixel>> DecodeAsync<TPixel>(Configuration configuration, Stream stream, CancellationToken cancellationToken)
                 where TPixel : unmanaged, IPixel<TPixel>
@@ -396,7 +396,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests
                 }
             }
 
-            public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream)
+            public Image<TPixel> Decode<TPixel>(Configuration configuration, Stream stream, CancellationToken cancellationToken)
                 where TPixel : unmanaged, IPixel<TPixel>
             {
                 InvocationCounts[this.callerName]++;
@@ -411,7 +411,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests
                 InvocationCounts[name] = 0;
             }
 
-            public Image Decode(Configuration configuration, Stream stream) => this.Decode<Rgba32>(configuration, stream);
+            public Image Decode(Configuration configuration, Stream stream, CancellationToken cancellationToken) => this.Decode<Rgba32>(configuration, stream, cancellationToken);
 
             public Task<Image<TPixel>> DecodeAsync<TPixel>(Configuration configuration, Stream stream, CancellationToken cancellationToken)
                 where TPixel : unmanaged, IPixel<TPixel>

--- a/tests/ImageSharp.Drawing.Tests/ValidateDisposedMemoryAllocationsAttribute.cs
+++ b/tests/ImageSharp.Drawing.Tests/ValidateDisposedMemoryAllocationsAttribute.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace SixLabors.ImageSharp.Drawing.Tests
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public class ValidateDisposedMemoryAllocationsAttribute : BeforeAfterTestAttribute
+    {
+        private readonly int max = 0;
+
+        public ValidateDisposedMemoryAllocationsAttribute()
+            : this(0)
+        {
+        }
+
+        public ValidateDisposedMemoryAllocationsAttribute(int max)
+        {
+            this.max = max;
+            if (max > 0)
+            {
+                Debug.WriteLine("Needs fixing, we shoudl have Zero undisposed memory allocations.");
+            }
+        }
+
+        public override void Before(MethodInfo methodUnderTest)
+            => MemoryAllocatorValidator.MonitorAllocations();
+
+        public override void After(MethodInfo methodUnderTest)
+        {
+            MemoryAllocatorValidator.ValidateAllocation(this.max);
+            MemoryAllocatorValidator.StopMonitoringAllocations();
+        }
+    }
+}

--- a/tests/ImageSharp.Drawing.Tests/ValidateDisposedMemoryAllocationsAttribute.cs
+++ b/tests/ImageSharp.Drawing.Tests/ValidateDisposedMemoryAllocationsAttribute.cs
@@ -11,28 +11,22 @@ namespace SixLabors.ImageSharp.Drawing.Tests
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class ValidateDisposedMemoryAllocationsAttribute : BeforeAfterTestAttribute
     {
-        private readonly int max = 0;
+        private readonly int expected = 0;
 
         public ValidateDisposedMemoryAllocationsAttribute()
             : this(0)
         {
         }
 
-        public ValidateDisposedMemoryAllocationsAttribute(int max)
-        {
-            this.max = max;
-            if (max > 0)
-            {
-                Debug.WriteLine("Needs fixing, we shoudl have Zero undisposed memory allocations.");
-            }
-        }
+        public ValidateDisposedMemoryAllocationsAttribute(int expected)
+            => this.expected = expected;
 
         public override void Before(MethodInfo methodUnderTest)
             => MemoryAllocatorValidator.MonitorAllocations();
 
         public override void After(MethodInfo methodUnderTest)
         {
-            MemoryAllocatorValidator.ValidateAllocation(this.max);
+            MemoryAllocatorValidator.ValidateAllocations(this.expected);
             MemoryAllocatorValidator.StopMonitoringAllocations();
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Like with SixLabors/ImageSharp#2082 this introduces the test helpers for validating Memory allocations tracked by our memory allocator.

~This is dependent on the code in SixLabors/ImageSharp#2082 for the required changes to the `MemoryDiagnostics` class to enable this.~ Merged

Also fixes #215 

