### PR TITLE
Use correct dimension for sourceY

### DIFF
--- a/src/ImageSharp.Drawing/Processing/ImageBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/ImageBrush.cs
@@ -161,7 +161,7 @@ namespace SixLabors.ImageSharp.Drawing.Processing
                 Span<TPixel> overlaySpan = overlay.Memory.Span;
 
                 int offsetX = x - this.offsetX;
-                int sourceY = ((y - this.offsetY) % this.sourceRegion.Width) + this.sourceRegion.Y;
+                int sourceY = ((y - this.offsetY) % this.sourceRegion.Height) + this.sourceRegion.Y;
                 Span<TPixel> sourceRow = this.sourceFrame.PixelBuffer.DangerousGetRowSpan(sourceY);
 
                 for (int i = 0; i < scanline.Length; i++)

--- a/tests/ImageSharp.Drawing.Tests/Drawing/FillImageBrushTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/FillImageBrushTests.cs
@@ -33,17 +33,52 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Drawing
             where TPixel : unmanaged, IPixel<TPixel>
         {
             byte[] data = TestFile.Create(TestImages.Png.Ducky).Bytes;
-            using (Image<TPixel> background = provider.GetImage())
-            using (Image overlay = provider.PixelType == PixelTypes.Rgba32
-                                       ? (Image)Image.Load<Bgra32>(data)
-                                       : Image.Load<Rgba32>(data))
-            {
-                var brush = new ImageBrush(overlay);
-                background.Mutate(c => c.Fill(brush));
+            using Image<TPixel> background = provider.GetImage();
+            using Image overlay = provider.PixelType == PixelTypes.Rgba32
+                                       ? Image.Load<Bgra32>(data)
+                                       : Image.Load<Rgba32>(data);
 
-                background.DebugSave(provider, appendSourceFileOrDescription: false);
-                background.CompareToReferenceOutput(provider, appendSourceFileOrDescription: false);
-            }
+            var brush = new ImageBrush(overlay);
+            background.Mutate(c => c.Fill(brush));
+
+            background.DebugSave(provider, appendSourceFileOrDescription: false);
+            background.CompareToReferenceOutput(provider, appendSourceFileOrDescription: false);
+        }
+
+        [Theory]
+        [WithTestPatternImage(200, 200, PixelTypes.Rgba32)]
+        public void CanDrawLandscapeImage<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            byte[] data = TestFile.Create(TestImages.Png.Ducky).Bytes;
+            using Image<TPixel> background = provider.GetImage();
+            using Image overlay = Image.Load<Rgba32>(data);
+
+            overlay.Mutate(c => c.Crop(new Rectangle(0, 0, 125, 90)));
+
+            var brush = new ImageBrush(overlay);
+            background.Mutate(c => c.Fill(brush));
+
+            background.DebugSave(provider, appendSourceFileOrDescription: false);
+            background.CompareToReferenceOutput(provider, appendSourceFileOrDescription: false);
+        }
+
+        [Theory]
+        [WithTestPatternImage(200, 200, PixelTypes.Rgba32)]
+        public void CanDrawPortraitImage<TPixel>(TestImageProvider<TPixel> provider)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            byte[] data = TestFile.Create(TestImages.Png.Ducky).Bytes;
+            using Image<TPixel> background = provider.GetImage();
+            using Image overlay = Image.Load<Rgba32>(data);
+
+            overlay.Mutate(c => c.Crop(new Rectangle(0, 0, 90, 125)));
+
+            var brush = new ImageBrush(overlay);
+            background.Mutate(c => c.Fill(brush));
+
+            background.DebugSave(provider, appendSourceFileOrDescription: false);
+            background.CompareToReferenceOutput(provider, appendSourceFileOrDescription: false);
         }
     }
 }

--- a/tests/Images/ReferenceOutput/Drawing/FillImageBrushTests/CanDrawLandscapeImage_Rgba32.png
+++ b/tests/Images/ReferenceOutput/Drawing/FillImageBrushTests/CanDrawLandscapeImage_Rgba32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f79a9486aee6b3201ba20876028c25b1251e70996af8e4ee4847ac294e87458b
+size 59884

--- a/tests/Images/ReferenceOutput/Drawing/FillImageBrushTests/CanDrawPortraitImage_Rgba32.png
+++ b/tests/Images/ReferenceOutput/Drawing/FillImageBrushTests/CanDrawPortraitImage_Rgba32.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb1807440c0a8abb05eb332b379dabff4b1be83f804cc3e2e65978a758373940
+size 48551


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #221 and adds tests

<!-- Thanks for contributing to ImageSharp.Drawing! -->
