### PR TITLE
Return empty path when outline width is less than or equal to zero

### DIFF
--- a/src/ImageSharp.Drawing/Shapes/EmptyPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/EmptyPath.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace SixLabors.ImageSharp.Drawing
+{
+    /// <summary>
+    /// A path that is always empty.
+    /// </summary>
+    public class EmptyPath : IPath
+    {
+        private EmptyPath(PathTypes pathType) => this.PathType = pathType;
+
+        /// <summary>
+        /// Gets the closed path instance of the empty path
+        /// </summary>
+        public static EmptyPath ClosedPath { get; } = new EmptyPath(PathTypes.Closed);
+
+        /// <summary>
+        /// Gets the open path instance of the empty path
+        /// </summary>
+        public static EmptyPath OpenPath { get; } = new EmptyPath(PathTypes.Open);
+
+        /// <inheritdoc />
+        public PathTypes PathType { get; }
+
+        /// <inheritdoc />
+        public RectangleF Bounds => RectangleF.Empty;
+
+        /// <inheritdoc />
+        public IPath AsClosedPath() => ClosedPath;
+
+        /// <inheritdoc />
+        public IEnumerable<ISimplePath> Flatten() => Array.Empty<ISimplePath>();
+
+        /// <inheritdoc />
+        public IPath Transform(Matrix3x2 matrix) => this;
+    }
+}

--- a/src/ImageSharp.Drawing/Shapes/OutlinePathExtensions.cs
+++ b/src/ImageSharp.Drawing/Shapes/OutlinePathExtensions.cs
@@ -37,6 +37,11 @@ namespace SixLabors.ImageSharp.Drawing
         /// <exception cref="ClipperException">Thrown when an offset cannot be calculated.</exception>
         public static IPath GenerateOutline(this IPath path, float width, JointStyle jointStyle, EndCapStyle endCapStyle)
         {
+            if (width <= 0)
+            {
+                return Path.Empty;
+            }
+
             ClipperOffset offset = new(MiterOffsetDelta);
             offset.AddPath(path, jointStyle, endCapStyle);
 
@@ -92,6 +97,11 @@ namespace SixLabors.ImageSharp.Drawing
         /// <exception cref="ClipperException">Thrown when an offset cannot be calculated.</exception>
         public static IPath GenerateOutline(this IPath path, float width, ReadOnlySpan<float> pattern, bool startOff, JointStyle jointStyle, EndCapStyle endCapStyle)
         {
+            if (width <= 0)
+            {
+                return Path.Empty;
+            }
+
             if (pattern.Length < 2)
             {
                 return path.GenerateOutline(width, jointStyle, endCapStyle);

--- a/src/ImageSharp.Drawing/Shapes/Path.cs
+++ b/src/ImageSharp.Drawing/Shapes/Path.cs
@@ -42,6 +42,11 @@ namespace SixLabors.ImageSharp.Drawing
         public Path(params ILineSegment[] segments)
             => this.lineSegments = segments ?? throw new ArgumentNullException(nameof(segments));
 
+        /// <summary>
+        /// Gets the default empty path.
+        /// </summary>
+        public static IPath Empty { get; } = EmptyPath.OpenPath;
+
         /// <inheritdoc/>
         bool ISimplePath.IsClosed => this.IsClosed;
 

--- a/tests/ImageSharp.Drawing.Tests/Shapes/Issues/Issue_224.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/Issues/Issue_224.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SixLabors.ImageSharp.Drawing.Tests
+{
+    /// <summary>
+    /// see https://github.com/SixLabors/ImageSharp.Drawing/issues/224
+    /// </summary>
+    public class Issue_224
+    {
+        [Fact]
+        public async Task OutliningWithZeroWidth_MultiplePatterns()
+        {
+            var shape = new RectangularPolygon(10, 10, 10, 10);
+
+            await this.CompletesIn(TimeSpan.FromSeconds(1), () =>
+            {
+                _ = shape.GenerateOutline(0, new float[] { 1, 2 });
+            });
+        }
+
+        [Fact]
+        public async Task OutliningWithZeroWidth_SinglePAttern()
+        {
+            var shape = new RectangularPolygon(10, 10, 10, 10);
+
+            await this.CompletesIn(TimeSpan.FromSeconds(1), () =>
+            {
+                _ = shape.GenerateOutline(0, new float[] { 1 });
+            });
+        }
+
+        [Fact]
+        public async Task OutliningWithZeroWidth_NoPattern()
+        {
+            var shape = new RectangularPolygon(10, 10, 10, 10);
+
+            await this.CompletesIn(TimeSpan.FromSeconds(1), () =>
+            {
+                _ = shape.GenerateOutline(0);
+            });
+        }
+
+        [Fact]
+        public async Task OutliningWithLessThanZeroWidth_MultiplePatterns()
+        {
+            var shape = new RectangularPolygon(10, 10, 10, 10);
+
+            await this.CompletesIn(TimeSpan.FromSeconds(1), () =>
+            {
+                _ = shape.GenerateOutline(-10, new float[] { 1, 2 });
+            });
+        }
+
+        [Fact]
+        public async Task OutliningWithLessThanZeroWidth_SinglePAttern()
+        {
+            var shape = new RectangularPolygon(10, 10, 10, 10);
+
+            await this.CompletesIn(TimeSpan.FromSeconds(1), () =>
+            {
+                _ = shape.GenerateOutline(-10, new float[] { 1 });
+            });
+        }
+
+        [Fact]
+        public async Task OutliningWithLessThanZeroWidth_NoPattern()
+        {
+            var shape = new RectangularPolygon(10, 10, 10, 10);
+
+            await this.CompletesIn(TimeSpan.FromSeconds(1), () =>
+            {
+                _ = shape.GenerateOutline(-10);
+            });
+        }
+
+        private async Task CompletesIn(TimeSpan span, Action action)
+        {
+            var task = Task.Run(action);
+            var timeout = Task.Delay(span);
+
+            var completed = await Task.WhenAny(task, timeout);
+
+            Assert.True(task == completed, $"Failed to compelete in {span}");
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

Updates the `GenerateOutline` extensions so that when an invalid width (<= 0) is specified that instead of looping it returns an `EmptyPath` (a new type to represent an empty path without addition allocations).

This resolves #224 