### PR TITLE
Determine minX/minY/maxX/maxY by iterating over points/paths only onc…

### DIFF
--- a/src/ImageSharp.Drawing/Shapes/InternalPath.cs
+++ b/src/ImageSharp.Drawing/Shapes/InternalPath.cs
@@ -80,13 +80,22 @@ namespace SixLabors.ImageSharp.Drawing
 
             if (this.points.Length > 0)
             {
-                float minX = this.points.Min(x => x.Point.X);
-                float maxX = this.points.Max(x => x.Point.X);
-                float minY = this.points.Min(x => x.Point.Y);
-                float maxY = this.points.Max(x => x.Point.Y);
+                float minX, minY, maxX, maxY, length;
+                length = 0;
+                minX = minY = float.MaxValue;
+                maxX = maxY = float.MinValue;
+
+                foreach (var point in this.points)
+                {
+                    length += point.Length;
+                    minX = Math.Min(point.Point.X, minX);
+                    minY = Math.Min(point.Point.Y, minY);
+                    maxX = Math.Max(point.Point.X, maxX);
+                    maxY = Math.Max(point.Point.Y, maxY);
+                }
 
                 this.Bounds = new RectangleF(minX, minY, maxX - minX, maxY - minY);
-                this.Length = this.points.Sum(x => x.Length);
+                this.Length = length;
             }
             else
             {

--- a/src/ImageSharp.Drawing/Shapes/PathCollection.cs
+++ b/src/ImageSharp.Drawing/Shapes/PathCollection.cs
@@ -40,11 +40,17 @@ namespace SixLabors.ImageSharp.Drawing
             }
             else
             {
-                float minX = this.paths.Min(x => x.Bounds.Left);
-                float maxX = this.paths.Max(x => x.Bounds.Right);
+                float minX, minY, maxX, maxY;
+                minX = minY = float.MaxValue;
+                maxX = maxY = float.MinValue;
 
-                float minY = this.paths.Min(x => x.Bounds.Top);
-                float maxY = this.paths.Max(x => x.Bounds.Bottom);
+                foreach (var path in this.paths)
+                {
+                    minX = Math.Min(path.Bounds.Left, minX);
+                    minY = Math.Min(path.Bounds.Top, minY);
+                    maxX = Math.Max(path.Bounds.Right, maxX);
+                    maxY = Math.Max(path.Bounds.Bottom, maxY);
+                }
 
                 this.Bounds = new RectangleF(minX, minY, maxX - minX, maxY - minY);
             }


### PR DESCRIPTION
…e instead of using Linq

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description

While investigating another (solved) issue, I saw this pattern of using Linq to get the minX/minY/length/etc. This iterates over the list multiple times and could be optimized by iterating only once and keeping track of min/max values.
