### PR TITLE
Enable nullability checks

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Brush.cs
+++ b/src/ImageSharp.Drawing/Processing/Brush.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 namespace SixLabors.ImageSharp.Drawing.Processing;
 
 /// <summary>
@@ -37,10 +35,10 @@ public abstract class Brush : IEquatable<Brush>
         where TPixel : unmanaged, IPixel<TPixel>;
 
     /// <inheritdoc/>
-    public abstract bool Equals(Brush other);
+    public abstract bool Equals(Brush? other);
 
     /// <inheritdoc/>
-    public override bool Equals(object obj) => this.Equals(obj as Brush);
+    public override bool Equals(object? obj) => this.Equals(obj as Brush);
 
     /// <inheritdoc/>
     public abstract override int GetHashCode();

--- a/src/ImageSharp.Drawing/Processing/DrawingOptionsDefaultsExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/DrawingOptionsDefaultsExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using System.Numerics;
 
 namespace SixLabors.ImageSharp.Drawing.Processing;
@@ -49,7 +47,7 @@ public static class DrawingOptionsDefaultsExtensions
     /// <returns>The matrix.</returns>
     public static Matrix3x2 GetDrawingTransform(this IImageProcessingContext context)
     {
-        if (context.Properties.TryGetValue(DrawingTransformMatrixKey, out object options) && options is Matrix3x2 go)
+        if (context.Properties.TryGetValue(DrawingTransformMatrixKey, out object? options) && options is Matrix3x2 go)
         {
             return go;
         }
@@ -66,7 +64,7 @@ public static class DrawingOptionsDefaultsExtensions
     /// <returns>The globally configured default matrix.</returns>
     public static Matrix3x2 GetDrawingTransform(this Configuration configuration)
     {
-        if (configuration.Properties.TryGetValue(DrawingTransformMatrixKey, out object options) && options is Matrix3x2 go)
+        if (configuration.Properties.TryGetValue(DrawingTransformMatrixKey, out object? options) && options is Matrix3x2 go)
         {
             return go;
         }

--- a/src/ImageSharp.Drawing/Processing/Extensions/DrawTextExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/Extensions/DrawTextExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using SixLabors.Fonts;
 using SixLabors.ImageSharp.Drawing.Processing.Processors.Text;
 
@@ -163,8 +161,8 @@ public static class DrawTextExtensions
         this IImageProcessingContext source,
         RichTextOptions textOptions,
         string text,
-        Brush brush,
-        Pen pen) =>
+        Brush? brush,
+        Pen? pen) =>
         source.DrawText(source.GetDrawingOptions(), textOptions, text, brush, pen);
 
     /// <summary>
@@ -221,8 +219,8 @@ public static class DrawTextExtensions
         DrawingOptions drawingOptions,
         string text,
         Font font,
-        Brush brush,
-        Pen pen,
+        Brush? brush,
+        Pen? pen,
         PointF location)
     {
         RichTextOptions textOptions = new(font) { Origin = location };
@@ -244,7 +242,7 @@ public static class DrawTextExtensions
         DrawingOptions drawingOptions,
         RichTextOptions textOptions,
         string text,
-        Brush brush,
-        Pen pen)
+        Brush? brush,
+        Pen? pen)
         => source.ApplyProcessor(new DrawTextProcessor(drawingOptions, textOptions, text, brush, pen));
 }

--- a/src/ImageSharp.Drawing/Processing/GradientBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/GradientBrush.cs
@@ -32,7 +32,7 @@ public abstract class GradientBrush : Brush
     protected ColorStop[] ColorStops { get; }
 
     /// <inheritdoc />
-    public override bool Equals(Brush other)
+    public override bool Equals(Brush? other)
     {
         if (other is GradientBrush brush)
         {

--- a/src/ImageSharp.Drawing/Processing/ImageBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/ImageBrush.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using System.Buffers;
 using SixLabors.ImageSharp.Memory;
 
@@ -47,7 +45,7 @@ public class ImageBrush : Brush
     }
 
     /// <inheritdoc />
-    public override bool Equals(Brush other)
+    public override bool Equals(Brush? other)
     {
         if (other is ImageBrush ib)
         {
@@ -83,10 +81,8 @@ public class ImageBrush : Brush
     private class ImageBrushApplicator<TPixel> : BrushApplicator<TPixel>
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        private ImageFrame<TPixel> sourceFrame;
-
-        private Image<TPixel> sourceImage;
-
+        private readonly ImageFrame<TPixel> sourceFrame;
+        private readonly Image<TPixel> sourceImage;
         private readonly bool shouldDisposeImage;
 
         /// <summary>
@@ -158,10 +154,7 @@ public class ImageBrush : Brush
                 this.sourceImage?.Dispose();
             }
 
-            this.sourceImage = null;
-            this.sourceFrame = null;
             this.isDisposed = true;
-
             base.Dispose(disposing);
         }
 

--- a/src/ImageSharp.Drawing/Processing/LinearGradientBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/LinearGradientBrush.cs
@@ -32,7 +32,7 @@ public sealed class LinearGradientBrush : GradientBrush
     }
 
     /// <inheritdoc/>
-    public override bool Equals(Brush other)
+    public override bool Equals(Brush? other)
     {
         if (other is LinearGradientBrush brush)
         {

--- a/src/ImageSharp.Drawing/Processing/PathGradientBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/PathGradientBrush.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using System.Numerics;
 using SixLabors.ImageSharp.Drawing.Utilities;
 
@@ -76,7 +74,7 @@ public sealed class PathGradientBrush : Brush
     }
 
     /// <inheritdoc />
-    public override bool Equals(Brush other)
+    public override bool Equals(Brush? other)
     {
         if (other is PathGradientBrush brush)
         {
@@ -123,7 +121,7 @@ public sealed class PathGradientBrush : Brush
         return new Color(colors.Select(c => (Vector4)c).Aggregate((p1, p2) => p1 + p2) / colors.Length);
     }
 
-    private static float DistanceBetween(PointF p1, PointF p2) => ((Vector2)(p2 - p1)).Length();
+    private static float DistanceBetween(Vector2 p1, Vector2 p2) => (p2 - p1).Length();
 
     private readonly struct Intersection
     {
@@ -178,13 +176,14 @@ public sealed class PathGradientBrush : Brush
 
         public Vector4 ColorAt(PointF point) => this.ColorAt(DistanceBetween(point, this.Start));
 
-        public bool Equals(Edge other)
-            => other.Start == this.Start &&
-                other.End == this.End &&
-                other.StartColor.Equals(this.StartColor) &&
-                other.EndColor.Equals(this.EndColor);
+        public bool Equals(Edge? other)
+            => other != null &&
+               other.Start == this.Start &&
+               other.End == this.End &&
+               other.StartColor.Equals(this.StartColor) &&
+               other.EndColor.Equals(this.EndColor);
 
-        public override bool Equals(object obj) => this.Equals(obj as Edge);
+        public override bool Equals(object? obj) => this.Equals(obj as Edge);
 
         public override int GetHashCode()
             => HashCode.Combine(this.Start, this.End, this.StartColor, this.EndColor);
@@ -249,7 +248,7 @@ public sealed class PathGradientBrush : Brush
         {
             get
             {
-                var point = new Vector2(x, y);
+                Vector2 point = new(x, y);
 
                 if (point == this.center)
                 {
@@ -278,7 +277,7 @@ public sealed class PathGradientBrush : Brush
                     return px;
                 }
 
-                var direction = Vector2.Normalize(point - this.center);
+                Vector2 direction = Vector2.Normalize(point - this.center);
                 Vector2 end = point + (direction * this.maxDistance);
 
                 (Edge Edge, Vector2 Point)? isc = this.FindIntersection(point, end);
@@ -294,7 +293,7 @@ public sealed class PathGradientBrush : Brush
                 float length = DistanceBetween(intersection, this.center);
                 float ratio = length > 0 ? DistanceBetween(intersection, point) / length : 0;
 
-                var color = Vector4.Lerp(edgeColor, this.centerColor, ratio);
+                Vector4 color = Vector4.Lerp(edgeColor, this.centerColor, ratio);
 
                 TPixel pixel = default;
                 pixel.FromScaledVector4(color);
@@ -305,8 +304,8 @@ public sealed class PathGradientBrush : Brush
         /// <inheritdoc />
         public override void Apply(Span<float> scanline, int x, int y)
         {
-            Span<float> amounts = this.blenderBuffers.AmountSpan.Slice(0, scanline.Length);
-            Span<TPixel> overlays = this.blenderBuffers.OverlaySpan.Slice(0, scanline.Length);
+            Span<float> amounts = this.blenderBuffers.AmountSpan[..scanline.Length];
+            Span<TPixel> overlays = this.blenderBuffers.OverlaySpan[..scanline.Length];
             float blendPercentage = this.Options.BlendPercentage;
 
             // TODO: Remove bounds checks.
@@ -355,7 +354,7 @@ public sealed class PathGradientBrush : Brush
         {
             Vector2 ip = default;
             Vector2 closestIntersection = default;
-            Edge closestEdge = null;
+            Edge? closestEdge = null;
             const float minDistance = float.MaxValue;
             foreach (Edge edge in this.edges)
             {
@@ -385,9 +384,9 @@ public sealed class PathGradientBrush : Brush
             Vector2 pv2 = point - v2;
             Vector2 pv3 = point - v3;
 
-            var d1 = Vector3.Cross(new Vector3(e1.X, e1.Y, 0), new Vector3(pv1.X, pv1.Y, 0));
-            var d2 = Vector3.Cross(new Vector3(e2.X, e2.Y, 0), new Vector3(pv2.X, pv2.Y, 0));
-            var d3 = Vector3.Cross(new Vector3(e3.X, e3.Y, 0), new Vector3(pv3.X, pv3.Y, 0));
+            Vector3 d1 = Vector3.Cross(new Vector3(e1.X, e1.Y, 0), new Vector3(pv1.X, pv1.Y, 0));
+            Vector3 d2 = Vector3.Cross(new Vector3(e2.X, e2.Y, 0), new Vector3(pv2.X, pv2.Y, 0));
+            Vector3 d3 = Vector3.Cross(new Vector3(e3.X, e3.Y, 0), new Vector3(pv3.X, pv3.Y, 0));
 
             if (Math.Sign(Vector3.Dot(d1, d2)) * Math.Sign(Vector3.Dot(d1, d3)) == -1 || Math.Sign(Vector3.Dot(d1, d2)) * Math.Sign(Vector3.Dot(d2, d3)) == -1)
             {

--- a/src/ImageSharp.Drawing/Processing/PatternBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/PatternBrush.cs
@@ -84,7 +84,7 @@ public sealed class PatternBrush : Brush
     }
 
     /// <inheritdoc />
-    public override bool Equals(Brush other)
+    public override bool Equals(Brush? other)
     {
         if (other is PatternBrush sb)
         {

--- a/src/ImageSharp.Drawing/Processing/PatternPen.cs
+++ b/src/ImageSharp.Drawing/Processing/PatternPen.cs
@@ -63,7 +63,7 @@ public class PatternPen : Pen
     }
 
     /// <inheritdoc/>
-    public override bool Equals(Pen other)
+    public override bool Equals(Pen? other)
     {
         if (other is PatternPen)
         {

--- a/src/ImageSharp.Drawing/Processing/Pen.cs
+++ b/src/ImageSharp.Drawing/Processing/Pen.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 namespace SixLabors.ImageSharp.Drawing.Processing;
 
 /// <summary>
@@ -104,15 +102,16 @@ public abstract class Pen : IEquatable<Pen>
     public abstract IPath GeneratePath(IPath path, float strokeWidth);
 
     /// <inheritdoc/>
-    public virtual bool Equals(Pen other)
-        => this.StrokeWidth == other.StrokeWidth
+    public virtual bool Equals(Pen? other)
+        => other != null
+        && this.StrokeWidth == other.StrokeWidth
         && this.JointStyle == other.JointStyle
         && this.EndCapStyle == other.EndCapStyle
         && this.StrokeFill.Equals(other.StrokeFill)
         && this.StrokePattern.SequenceEqual(other.StrokePattern);
 
     /// <inheritdoc/>
-    public override bool Equals(object obj) => this.Equals(obj as Pen);
+    public override bool Equals(object? obj) => this.Equals(obj as Pen);
 
     /// <inheritdoc/>
     public override int GetHashCode()

--- a/src/ImageSharp.Drawing/Processing/Pen.cs
+++ b/src/ImageSharp.Drawing/Processing/Pen.cs
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.Drawing.Processing;
 /// </remarks>
 public abstract class Pen : IEquatable<Pen>
 {
-    private readonly float[] pattern;
+    private readonly float[]? pattern;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Pen"/> class.

--- a/src/ImageSharp.Drawing/Processing/Pen.cs
+++ b/src/ImageSharp.Drawing/Processing/Pen.cs
@@ -21,7 +21,7 @@ namespace SixLabors.ImageSharp.Drawing.Processing;
 /// </remarks>
 public abstract class Pen : IEquatable<Pen>
 {
-    private readonly float[]? pattern;
+    private readonly float[] pattern;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Pen"/> class.
@@ -50,7 +50,9 @@ public abstract class Pen : IEquatable<Pen>
     /// <param name="strokePattern">The stroke pattern.</param>
     protected Pen(Brush strokeFill, float strokeWidth, float[] strokePattern)
     {
+        Guard.NotNull(strokeFill, nameof(strokeFill));
         Guard.MustBeGreaterThan(strokeWidth, 0, nameof(strokeWidth));
+        Guard.NotNull(strokePattern, nameof(strokePattern));
 
         this.StrokeFill = strokeFill;
         this.StrokeWidth = strokeWidth;
@@ -115,7 +117,5 @@ public abstract class Pen : IEquatable<Pen>
 
     /// <inheritdoc/>
     public override int GetHashCode()
-
-        // TODO: StrokePattern should be part of the hash-code.
-        => HashCode.Combine(this.StrokeWidth, this.JointStyle, this.EndCapStyle, this.StrokeFill);
+        => HashCode.Combine(this.StrokeWidth, this.JointStyle, this.EndCapStyle, this.StrokeFill, this.pattern);
 }

--- a/src/ImageSharp.Drawing/Processing/PenOptions.cs
+++ b/src/ImageSharp.Drawing/Processing/PenOptions.cs
@@ -50,7 +50,7 @@ public struct PenOptions
 
         this.StrokeFill = strokeFill;
         this.StrokeWidth = strokeWidth;
-        this.StrokePattern = strokePattern;
+        this.StrokePattern = strokePattern ?? Pens.EmptyPattern;
         this.JointStyle = JointStyle.Square;
         this.EndCapStyle = EndCapStyle.Butt;
     }
@@ -68,7 +68,7 @@ public struct PenOptions
     /// <summary>
     /// Gets the stroke pattern.
     /// </summary>
-    public float[]? StrokePattern { get; }
+    public float[] StrokePattern { get; }
 
     /// <summary>
     /// Gets or sets the joint style.

--- a/src/ImageSharp.Drawing/Processing/PenOptions.cs
+++ b/src/ImageSharp.Drawing/Processing/PenOptions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 namespace SixLabors.ImageSharp.Drawing.Processing;
 
 /// <summary>
@@ -35,7 +33,7 @@ public struct PenOptions
     /// <param name="color">The color.</param>
     /// <param name="strokeWidth">The stroke width in px units.</param>
     /// <param name="strokePattern">The stroke pattern.</param>
-    public PenOptions(Color color, float strokeWidth, float[] strokePattern)
+    public PenOptions(Color color, float strokeWidth, float[]? strokePattern)
         : this(new SolidBrush(color), strokeWidth, strokePattern)
     {
     }
@@ -46,7 +44,7 @@ public struct PenOptions
     /// <param name="strokeFill">The brush used to fill the stroke outline.</param>
     /// <param name="strokeWidth">The stroke width in px units.</param>
     /// <param name="strokePattern">The stroke pattern.</param>
-    public PenOptions(Brush strokeFill, float strokeWidth, float[] strokePattern)
+    public PenOptions(Brush strokeFill, float strokeWidth, float[]? strokePattern)
     {
         Guard.MustBeGreaterThan(strokeWidth, 0, nameof(strokeWidth));
 
@@ -70,7 +68,7 @@ public struct PenOptions
     /// <summary>
     /// Gets the stroke pattern.
     /// </summary>
-    public float[] StrokePattern { get; }
+    public float[]? StrokePattern { get; }
 
     /// <summary>
     /// Gets or sets the joint style.

--- a/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using SixLabors.ImageSharp.Processing.Processors;
 
 namespace SixLabors.ImageSharp.Drawing.Processing.Processors.Text;
@@ -20,7 +18,7 @@ public class DrawTextProcessor : IImageProcessor
     /// <param name="text">The text we want to render</param>
     /// <param name="brush">The brush to source pixel colors from.</param>
     /// <param name="pen">The pen to outline text with.</param>
-    public DrawTextProcessor(DrawingOptions drawingOptions, RichTextOptions textOptions, string text, Brush brush, Pen pen)
+    public DrawTextProcessor(DrawingOptions drawingOptions, RichTextOptions textOptions, string text, Brush? brush, Pen? pen)
     {
         Guard.NotNull(text, nameof(text));
         if (brush is null && pen is null)
@@ -38,7 +36,7 @@ public class DrawTextProcessor : IImageProcessor
     /// <summary>
     /// Gets the brush used to fill the glyphs.
     /// </summary>
-    public Brush Brush { get; }
+    public Brush? Brush { get; }
 
     /// <summary>
     /// Gets the <see cref="Processing.DrawingOptions"/> defining blending modes and shape drawing settings.
@@ -58,7 +56,7 @@ public class DrawTextProcessor : IImageProcessor
     /// <summary>
     /// Gets the pen used for outlining the text, if Null then we will not outline
     /// </summary>
-    public Pen Pen { get; }
+    public Pen? Pen { get; }
 
     /// <summary>
     /// Gets the location to draw the text at.

--- a/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
@@ -105,7 +105,8 @@ internal class DrawTextProcessor<TPixel> : ImageProcessor<TPixel>
             }
         }
 
-        if (this.textRenderer.DrawingOperations.Count > 0)
+        // Not null, initialized in earlier event.
+        if (this.textRenderer!.DrawingOperations.Count > 0)
         {
             Draw(this.textRenderer.DrawingOperations.OrderBy(x => x.RenderPass));
         }

--- a/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using System.Numerics;
 using SixLabors.Fonts;
 using SixLabors.ImageSharp.Memory;
@@ -17,7 +15,7 @@ namespace SixLabors.ImageSharp.Drawing.Processing.Processors.Text;
 internal class DrawTextProcessor<TPixel> : ImageProcessor<TPixel>
     where TPixel : unmanaged, IPixel<TPixel>
 {
-    private RichTextGlyphRenderer textRenderer;
+    private RichTextGlyphRenderer? textRenderer;
     private readonly DrawTextProcessor definition;
 
     public DrawTextProcessor(Configuration configuration, DrawTextProcessor definition, Image<TPixel> source, Rectangle sourceRectangle)
@@ -101,7 +99,7 @@ internal class DrawTextProcessor<TPixel> : ImageProcessor<TPixel>
                 for (int row = firstRow; row < end; row++)
                 {
                     int y = startY + row;
-                    Span<float> span = buffer.DangerousGetRowSpan(row).Slice(offsetSpan);
+                    Span<float> span = buffer.DangerousGetRowSpan(row)[offsetSpan..];
                     app.Apply(span, startX, y);
                 }
             }

--- a/src/ImageSharp.Drawing/Processing/Processors/Text/RichTextGlyphRenderer.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/RichTextGlyphRenderer.cs
@@ -62,7 +62,7 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
         this.defaultBrush = brush;
         this.DrawingOperations = new List<DrawingOperation>();
 
-        IPath path = textOptions.Path;
+        IPath? path = textOptions.Path;
         if (path is not null)
         {
             // Turn of caching. The chances of a hit are near-zero.

--- a/src/ImageSharp.Drawing/Processing/Processors/Text/RichTextGlyphRenderer.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/RichTextGlyphRenderer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using SixLabors.Fonts;
@@ -24,15 +22,15 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
 
     private readonly DrawingOptions drawingOptions;
     private readonly MemoryAllocator memoryAllocator;
-    private readonly Pen defaultPen;
-    private readonly Brush defaultBrush;
-    private readonly IPathInternals path;
+    private readonly Pen? defaultPen;
+    private readonly Brush? defaultBrush;
+    private readonly IPathInternals? path;
     private bool isDisposed;
 
     private readonly Dictionary<Color, Brush> brushLookup = new();
-    private TextRun currentTextRun;
-    private Brush currentBrush;
-    private Pen currentPen;
+    private TextRun? currentTextRun;
+    private Brush? currentBrush;
+    private Pen? currentPen;
     private Color? currentColor;
     private TextDecorationDetails? currentUnderline;
     private TextDecorationDetails? currentStrikeout;
@@ -54,8 +52,8 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
         RichTextOptions textOptions,
         DrawingOptions drawingOptions,
         MemoryAllocator memoryAllocator,
-        Pen pen,
-        Brush brush)
+        Pen? pen,
+        Brush? brush)
         : base(drawingOptions.Transform)
     {
         this.drawingOptions = drawingOptions;
@@ -116,7 +114,7 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
             // Create a cache entry for the glyph.
             // We need to apply the default transform to the bounds to get the correct size
             // for comparison with future glyphs. We can use this cached glyph anywhere in the text block.
-            var currentBounds = RectangleF.Transform(
+            RectangleF currentBounds = RectangleF.Transform(
                    new RectangleF(bounds.Location, new(bounds.Width, bounds.Height)),
                    this.drawingOptions.Transform);
 
@@ -150,8 +148,8 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
 
     public override TextDecorations EnabledDecorations()
     {
-        TextRun run = this.currentTextRun;
-        TextDecorations decorations = run.TextDecorations;
+        TextRun? run = this.currentTextRun;
+        TextDecorations decorations = run?.TextDecorations ?? TextDecorations.None;
 
         if (this.currentTextRun is RichTextRun drawingRun)
         {
@@ -199,7 +197,7 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
             return;
         }
 
-        Pen pen = null;
+        Pen? pen = null;
         if (this.currentTextRun is RichTextRun drawingRun)
         {
             if (textDecorations == TextDecorations.Strikeout)
@@ -224,8 +222,9 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
         else
         {
             // Clamp the thickness to whole pixels.
+            // Brush cannot be null if pen is null.
             thickness = MathF.Max(1F, MathF.Round(thickness));
-            pen = new SolidPen(this.currentBrush ?? this.defaultBrush, thickness);
+            pen = new SolidPen((this.currentBrush ?? this.defaultBrush)!, thickness);
         }
 
         // Drawing is always centered around the point so we need to offset by half.
@@ -275,7 +274,7 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
             renderFill = true;
             if (this.currentColor.HasValue)
             {
-                if (this.brushLookup.TryGetValue(this.currentColor.Value, out Brush brush))
+                if (this.brushLookup.TryGetValue(this.currentColor.Value, out Brush? brush))
                 {
                     this.currentBrush = brush;
                 }
@@ -309,7 +308,7 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
 
             if (renderOutline)
             {
-                path = this.currentPen.GeneratePath(path);
+                path = this.currentPen!.GeneratePath(path);
                 renderData.OutlineMap = this.Render(path);
             }
 
@@ -361,7 +360,7 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
             {
                 RenderLocation = renderLocation,
                 Map = renderData.FillMap,
-                Brush = this.currentBrush,
+                Brush = this.currentBrush!,
                 RenderPass = RenderOrderFill
             });
         }
@@ -372,7 +371,7 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
             {
                 RenderLocation = renderLocation,
                 Map = renderData.OutlineMap,
-                Brush = this.currentPen?.StrokeFill ?? this.currentBrush,
+                Brush = this.currentPen?.StrokeFill ?? this.currentBrush!,
                 RenderPass = RenderOrderOutline
             });
         }
@@ -538,7 +537,7 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
         // Take the path inside the path builder, scan thing and generate a Buffer2D representing the glyph.
         Buffer2D<float> buffer = this.memoryAllocator.Allocate2D<float>(size.Width, size.Height, AllocationOptions.Clean);
 
-        var scanner = PolygonScanner.Create(
+        PolygonScanner scanner = PolygonScanner.Create(
             offsetPath,
             0,
             size.Height,

--- a/src/ImageSharp.Drawing/Processing/RadialGradientBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/RadialGradientBrush.cs
@@ -28,7 +28,7 @@ public sealed class RadialGradientBrush : GradientBrush
     }
 
     /// <inheritdoc/>
-    public override bool Equals(Brush other)
+    public override bool Equals(Brush? other)
     {
         if (other is RadialGradientBrush brush)
         {

--- a/src/ImageSharp.Drawing/Processing/RecolorBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/RecolorBrush.cs
@@ -53,7 +53,7 @@ public sealed class RecolorBrush : Brush
             this.Threshold);
 
     /// <inheritdoc />
-    public override bool Equals(Brush other)
+    public override bool Equals(Brush? other)
     {
         if (other is RecolorBrush brush)
         {

--- a/src/ImageSharp.Drawing/Processing/RichTextOptions.cs
+++ b/src/ImageSharp.Drawing/Processing/RichTextOptions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using SixLabors.Fonts;
 
 namespace SixLabors.ImageSharp.Drawing.Processing;
@@ -46,5 +44,5 @@ public class RichTextOptions : TextOptions
     /// When this property is not <see langword="null"/> the <see cref="TextOptions.Origin"/>
     /// property is automatically applied as a translation to a copy of the path for processing.
     /// </remarks>
-    public IPath Path { get; set; }
+    public IPath? Path { get; set; }
 }

--- a/src/ImageSharp.Drawing/Processing/RichTextRun.cs
+++ b/src/ImageSharp.Drawing/Processing/RichTextRun.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using SixLabors.Fonts;
 
 namespace SixLabors.ImageSharp.Drawing.Processing;
@@ -15,25 +13,25 @@ public class RichTextRun : TextRun
     /// <summary>
     /// Gets or sets the brush used for filling this run.
     /// </summary>
-    public Brush Brush { get; set; }
+    public Brush? Brush { get; set; }
 
     /// <summary>
     /// Gets or sets the pen used for outlining this run.
     /// </summary>
-    public Pen Pen { get; set; }
+    public Pen? Pen { get; set; }
 
     /// <summary>
     /// Gets or sets the pen used for drawing strikeout features for this run.
     /// </summary>
-    public Pen StrikeoutPen { get; set; }
+    public Pen? StrikeoutPen { get; set; }
 
     /// <summary>
     /// Gets or sets the pen used for drawing underline features for this run.
     /// </summary>
-    public Pen UnderlinePen { get; set; }
+    public Pen? UnderlinePen { get; set; }
 
     /// <summary>
     /// Gets or sets the pen used for drawing overline features for this run.
     /// </summary>
-    public Pen OverlinePen { get; set; }
+    public Pen? OverlinePen { get; set; }
 }

--- a/src/ImageSharp.Drawing/Processing/ShapeGraphicOptionsDefaultsExtensions.cs
+++ b/src/ImageSharp.Drawing/Processing/ShapeGraphicOptionsDefaultsExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 namespace SixLabors.ImageSharp.Drawing.Processing;
 
 /// <summary>
@@ -63,16 +61,14 @@ public static class ShapeGraphicOptionsDefaultsExtensions
     /// <returns>The globally configured default options.</returns>
     public static ShapeOptions GetShapeOptions(this IImageProcessingContext context)
     {
-        if (context.Properties.TryGetValue(typeof(ShapeOptions), out object options) && options is ShapeOptions go)
+        if (context.Properties.TryGetValue(typeof(ShapeOptions), out object? options) && options is ShapeOptions go)
         {
             return go;
         }
 
-        ShapeOptions configOptions = context.Configuration.GetShapeOptions();
-
         // do not cache the fall back to config into the the processing context
         // in case someone want to change the value on the config and expects it reflow thru
-        return configOptions;
+        return context.Configuration.GetShapeOptions();
     }
 
     /// <summary>
@@ -82,12 +78,12 @@ public static class ShapeGraphicOptionsDefaultsExtensions
     /// <returns>The globally configured default options.</returns>
     public static ShapeOptions GetShapeOptions(this Configuration configuration)
     {
-        if (configuration.Properties.TryGetValue(typeof(ShapeOptions), out object options) && options is ShapeOptions go)
+        if (configuration.Properties.TryGetValue(typeof(ShapeOptions), out object? options) && options is ShapeOptions go)
         {
             return go;
         }
 
-        var configOptions = new ShapeOptions();
+        ShapeOptions configOptions = new();
 
         // capture the fallback so the same instance will always be returned in case its mutated
         configuration.Properties[typeof(ShapeOptions)] = configOptions;

--- a/src/ImageSharp.Drawing/Processing/SolidBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/SolidBrush.cs
@@ -30,7 +30,7 @@ public sealed class SolidBrush : Brush
         RectangleF region) => new SolidBrushApplicator<TPixel>(configuration, options, source, this.Color.ToPixel<TPixel>());
 
     /// <inheritdoc/>
-    public override bool Equals(Brush other)
+    public override bool Equals(Brush? other)
     {
         if (other is SolidBrush sb)
         {

--- a/src/ImageSharp.Drawing/Processing/SolidPen.cs
+++ b/src/ImageSharp.Drawing/Processing/SolidPen.cs
@@ -56,7 +56,7 @@ public class SolidPen : Pen
     }
 
     /// <inheritdoc/>
-    public override bool Equals(Pen other)
+    public override bool Equals(Pen? other)
     {
         if (other is SolidPen)
         {

--- a/src/ImageSharp.Drawing/Shapes/ComplexPolygon.cs
+++ b/src/ImageSharp.Drawing/Shapes/ComplexPolygon.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
 namespace SixLabors.ImageSharp.Drawing;
@@ -35,7 +32,7 @@ public sealed class ComplexPolygon : IPath, IPathInternals, IInternalPathOwner
     /// </summary>
     /// <param name="paths">The paths.</param>
     public ComplexPolygon(IEnumerable<IPath> paths)
-        : this(paths?.ToArray())
+        : this(paths.ToArray())
     {
     }
 
@@ -82,7 +79,7 @@ public sealed class ComplexPolygon : IPath, IPathInternals, IInternalPathOwner
 
                 foreach (ISimplePath s in p.Flatten())
                 {
-                    var ip = new InternalPath(s.Points, s.IsClosed);
+                    InternalPath ip = new(s.Points, s.IsClosed);
                     length += ip.Length;
                     this.internalPaths.Add(ip);
                 }
@@ -120,7 +117,7 @@ public sealed class ComplexPolygon : IPath, IPathInternals, IInternalPathOwner
             return this;
         }
 
-        var shapes = new IPath[this.paths.Length];
+        IPath[] shapes = new IPath[this.paths.Length];
         int i = 0;
         foreach (IPath s in this.Paths)
         {
@@ -133,7 +130,7 @@ public sealed class ComplexPolygon : IPath, IPathInternals, IInternalPathOwner
     /// <inheritdoc />
     public IEnumerable<ISimplePath> Flatten()
     {
-        var paths = new List<ISimplePath>();
+        List<ISimplePath> paths = new();
         foreach (IPath path in this.Paths)
         {
             paths.AddRange(path.Flatten());
@@ -150,7 +147,7 @@ public sealed class ComplexPolygon : IPath, IPathInternals, IInternalPathOwner
             return this;
         }
 
-        var paths = new IPath[this.paths.Length];
+        IPath[] paths = new IPath[this.paths.Length];
         for (int i = 0; i < this.paths.Length; i++)
         {
             paths[i] = this.paths[i].AsClosedPath();
@@ -182,6 +179,5 @@ public sealed class ComplexPolygon : IPath, IPathInternals, IInternalPathOwner
     IReadOnlyList<InternalPath> IInternalPathOwner.GetRingsAsInternalPath()
         => this.internalPaths;
 
-    [DoesNotReturn]
     private static InvalidOperationException ThrowOutOfRange() => new("Should not be possible to reach this line");
 }

--- a/src/ImageSharp.Drawing/Shapes/Path.cs
+++ b/src/ImageSharp.Drawing/Shapes/Path.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
 
@@ -15,7 +14,7 @@ namespace SixLabors.ImageSharp.Drawing;
 public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
 {
     private readonly ILineSegment[] lineSegments;
-    private InternalPath innerPath;
+    private InternalPath? innerPath;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Path"/> class.
@@ -31,7 +30,7 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
     /// </summary>
     /// <param name="segments">The segments.</param>
     public Path(IEnumerable<ILineSegment> segments)
-        : this(segments?.ToArray())
+        : this(segments.ToArray())
     {
     }
 
@@ -49,7 +48,10 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
     /// </summary>
     /// <param name="segments">The segments.</param>
     public Path(params ILineSegment[] segments)
-        => this.lineSegments = segments ?? throw new ArgumentNullException(nameof(segments));
+    {
+        ArgumentNullException.ThrowIfNull(segments);
+        this.lineSegments = segments ?? throw new ArgumentNullException(nameof(segments));
+    }
 
     /// <summary>
     /// Gets the default empty path.
@@ -97,7 +99,7 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
             return this;
         }
 
-        var segments = new ILineSegment[this.lineSegments.Length];
+        ILineSegment[] segments = new ILineSegment[this.lineSegments.Length];
 
         for (int i = 0; i < this.LineSegments.Count; i++)
         {
@@ -140,7 +142,7 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
     /// This parameter is passed uninitialized.
     /// </param>
     /// <returns><see langword="true"/> if the input value can be parsed and converted; otherwise, <see langword="false"/>.</returns>
-    public static bool TryParseSvgPath(string svgPath, out IPath value)
+    public static bool TryParseSvgPath(string svgPath, [NotNullWhen(true)] out IPath? value)
         => TryParseSvgPath(svgPath.AsSpan(), out value);
 
     /// <summary>
@@ -152,11 +154,11 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
     /// This parameter is passed uninitialized.
     /// </param>
     /// <returns><see langword="true"/> if the input value can be parsed and converted; otherwise, <see langword="false"/>.</returns>
-    public static bool TryParseSvgPath(ReadOnlySpan<char> svgPath, out IPath value)
+    public static bool TryParseSvgPath(ReadOnlySpan<char> svgPath, [NotNullWhen(true)] out IPath? value)
     {
         value = null;
 
-        var builder = new PathBuilder();
+        PathBuilder builder = new();
 
         PointF first = PointF.Empty;
         PointF c = PointF.Empty;
@@ -199,7 +201,7 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
                     relative = true;
                 }
 
-                svgPath = TrimSeparator(svgPath.Slice(1));
+                svgPath = TrimSeparator(svgPath[1..]);
             }
 
             switch (op)
@@ -302,8 +304,7 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
                 case '~':
                     svgPath = FindPoint(svgPath, relative, c, out point1);
                     svgPath = FindPoint(svgPath, relative, c, out point2);
-                    builder.MoveTo(point1);
-                    builder.LineTo(point2);
+                    builder.MoveTo(point1).LineTo(point2);
                     break;
                 default:
                     return false;
@@ -324,7 +325,7 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
     private static bool TryTrimSeparator(ref ReadOnlySpan<char> str)
     {
         ReadOnlySpan<char> result = TrimSeparator(str);
-        if (str.Slice(str.Length - result.Length).StartsWith(result))
+        if (str[^result.Length..].StartsWith(result))
         {
             str = result;
             return true;
@@ -336,7 +337,7 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
     private static bool TryFindScaler(ref ReadOnlySpan<char> str, out float value)
     {
         ReadOnlySpan<char> result = FindScaler(str, out float valueInner);
-        if (str.Slice(str.Length - result.Length).StartsWith(result))
+        if (str[^result.Length..].StartsWith(result))
         {
             value = valueInner;
             str = result;
@@ -350,7 +351,7 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
     private static bool TryFindPoint(ref ReadOnlySpan<char> str, bool relative, PointF current, out PointF value)
     {
         ReadOnlySpan<char> result = FindPoint(str, relative, current, out PointF valueInner);
-        if (str.Slice(str.Length - result.Length).StartsWith(result))
+        if (str[^result.Length..].StartsWith(result))
         {
             value = valueInner;
             str = result;
@@ -384,8 +385,8 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
         {
             if (IsSeparator(str[i]) || i == str.Length)
             {
-                scaler = ParseFloat(str.Slice(0, i));
-                return str.Slice(i);
+                scaler = ParseFloat(str[..i]);
+                return str[i..];
             }
         }
 
@@ -416,7 +417,7 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
             }
         }
 
-        return data.Slice(idx);
+        return data[idx..];
     }
 
     private static float ParseFloat(ReadOnlySpan<char> str)

--- a/src/ImageSharp.Drawing/Shapes/Path.cs
+++ b/src/ImageSharp.Drawing/Shapes/Path.cs
@@ -50,7 +50,7 @@ public class Path : IPath, ISimplePath, IPathInternals, IInternalPathOwner
     public Path(params ILineSegment[] segments)
     {
         ArgumentNullException.ThrowIfNull(segments);
-        this.lineSegments = segments ?? throw new ArgumentNullException(nameof(segments));
+        this.lineSegments = segments;
     }
 
     /// <summary>

--- a/src/ImageSharp.Drawing/Shapes/PathBuilder.cs
+++ b/src/ImageSharp.Drawing/Shapes/PathBuilder.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
 namespace SixLabors.ImageSharp.Drawing;
@@ -446,6 +445,7 @@ public class PathBuilder
     /// <summary>
     /// Clears all drawn paths, Leaving any applied transforms.
     /// </summary>
+    [MemberNotNull(nameof(this.currentFigure))]
     public void Clear()
     {
         this.currentFigure = new Figure();

--- a/src/ImageSharp.Drawing/Shapes/PathCollection.cs
+++ b/src/ImageSharp.Drawing/Shapes/PathCollection.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using System.Collections;
 using System.Numerics;
 
@@ -21,7 +19,7 @@ public class PathCollection : IPathCollection
     /// </summary>
     /// <param name="paths">The collection of paths</param>
     public PathCollection(IEnumerable<IPath> paths)
-        : this(paths?.ToArray())
+        : this(paths.ToArray())
     {
     }
 
@@ -64,7 +62,7 @@ public class PathCollection : IPathCollection
     /// <inheritdoc />
     public IPathCollection Transform(Matrix3x2 matrix)
     {
-        var result = new IPath[this.paths.Length];
+        IPath[] result = new IPath[this.paths.Length];
 
         for (int i = 0; i < this.paths.Length && i < result.Length; i++)
         {

--- a/src/ImageSharp.Drawing/Shapes/Rasterization/ScanEdgeCollection.cs
+++ b/src/ImageSharp.Drawing/Shapes/Rasterization/ScanEdgeCollection.cs
@@ -1,23 +1,20 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using System.Buffers;
 using SixLabors.ImageSharp.Memory;
 
 namespace SixLabors.ImageSharp.Drawing.Shapes.Rasterization;
 
-internal partial class ScanEdgeCollection : IDisposable
+internal sealed partial class ScanEdgeCollection : IDisposable
 {
-    private IMemoryOwner<ScanEdge> buffer;
-
+    private readonly IMemoryOwner<ScanEdge> buffer;
     private Memory<ScanEdge> memory;
 
     private ScanEdgeCollection(IMemoryOwner<ScanEdge> buffer, int count)
     {
         this.buffer = buffer;
-        this.memory = buffer.Memory.Slice(0, count);
+        this.memory = buffer.Memory[..count];
     }
 
     public Span<ScanEdge> Edges => this.memory.Span;
@@ -32,7 +29,6 @@ internal partial class ScanEdgeCollection : IDisposable
         }
 
         this.buffer.Dispose();
-        this.buffer = null;
         this.memory = default;
     }
 
@@ -41,7 +37,7 @@ internal partial class ScanEdgeCollection : IDisposable
         MemoryAllocator allocator,
         int subsampling)
     {
-        using TessellatedMultipolygon multipolygon = TessellatedMultipolygon.Create(polygon, allocator);
-        return Create(multipolygon, allocator, subsampling);
+        using TessellatedMultipolygon multiPolygon = TessellatedMultipolygon.Create(polygon, allocator);
+        return Create(multiPolygon, allocator, subsampling);
     }
 }

--- a/src/ImageSharp.Drawing/Shapes/Text/TextBuilder.cs
+++ b/src/ImageSharp.Drawing/Shapes/Text/TextBuilder.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using System.Numerics;
 using SixLabors.Fonts;
 using SixLabors.ImageSharp.Drawing.Text;
@@ -52,7 +50,7 @@ public static class TextBuilder
     {
         // When a path is specified we should explicitly follow that path
         // and not adjust the origin. Any translation should be applied to the path.
-        if (path is not null && options.Origin != Vector2.Zero)
+        if (options.Origin != Vector2.Zero)
         {
             TextOptions clone = new(options)
             {

--- a/src/ImageSharp.Drawing/Utilities/ThreadLocalBlenderBuffers.cs
+++ b/src/ImageSharp.Drawing/Utilities/ThreadLocalBlenderBuffers.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-#nullable disable
-
 using System.Buffers;
 using SixLabors.ImageSharp.Memory;
 
@@ -11,39 +9,31 @@ namespace SixLabors.ImageSharp.Drawing.Utilities;
 internal class ThreadLocalBlenderBuffers<TPixel> : IDisposable
     where TPixel : unmanaged, IPixel<TPixel>
 {
-    private ThreadLocal<BufferOwner> data;
+    private readonly ThreadLocal<BufferOwner> data;
 
     // amountBufferOnly:true is for SolidBrush, which doesn't need the overlay buffer (it will be dummy)
     public ThreadLocalBlenderBuffers(MemoryAllocator allocator, int scanlineWidth, bool amountBufferOnly = false)
-    {
-        this.data = new ThreadLocal<BufferOwner>(() => new BufferOwner(allocator, scanlineWidth, amountBufferOnly), true);
-    }
+        => this.data = new ThreadLocal<BufferOwner>(() => new BufferOwner(allocator, scanlineWidth, amountBufferOnly), true);
 
-    public Span<float> AmountSpan => this.data.Value.AmountSpan;
+    public Span<float> AmountSpan => this.data.Value!.AmountSpan;
 
-    public Span<TPixel> OverlaySpan => this.data.Value.OverlaySpan;
+    public Span<TPixel> OverlaySpan => this.data.Value!.OverlaySpan;
 
     /// <inheritdoc />
     public void Dispose()
     {
-        if (this.data == null)
-        {
-            return;
-        }
-
         foreach (BufferOwner d in this.data.Values)
         {
             d.Dispose();
         }
 
         this.data.Dispose();
-        this.data = null;
     }
 
     private sealed class BufferOwner : IDisposable
     {
         private readonly IMemoryOwner<float> amountBuffer;
-        private readonly IMemoryOwner<TPixel> overlayBuffer;
+        private readonly IMemoryOwner<TPixel>? overlayBuffer;
 
         public BufferOwner(MemoryAllocator allocator, int scanlineLength, bool amountBufferOnly)
         {
@@ -53,7 +43,18 @@ internal class ThreadLocalBlenderBuffers<TPixel> : IDisposable
 
         public Span<float> AmountSpan => this.amountBuffer.Memory.Span;
 
-        public Span<TPixel> OverlaySpan => this.overlayBuffer.Memory.Span;
+        public Span<TPixel> OverlaySpan
+        {
+            get
+            {
+                if (this.overlayBuffer != null)
+                {
+                    return this.overlayBuffer.Memory.Span;
+                }
+
+                return Span<TPixel>.Empty;
+            }
+        }
 
         public void Dispose()
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Removes all `#nullable disable` compiler instructions except for PolygonClipper (_which looks like a ton of work_)
Performs minor cleanup to remove IDE warnings

<!-- Thanks for contributing to ImageSharp.Drawing! -->
