### PR TITLE
Additional drawing performance fixes

### DIFF
--- a/src/ImageSharp.Drawing/Shapes/PolygonClipper/Clipper.cs
+++ b/src/ImageSharp.Drawing/Shapes/PolygonClipper/Clipper.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-using System.Numerics;
-
 namespace SixLabors.ImageSharp.Drawing.Shapes.PolygonClipper;
 
 /// <summary>
@@ -10,8 +8,7 @@ namespace SixLabors.ImageSharp.Drawing.Shapes.PolygonClipper;
 /// </summary>
 internal class Clipper
 {
-    // To make the floating point polygons compatable with clipper we have to scale them.
-    private const float ScalingFactor = 1000F;
+    // To make the floating point polygons compatible with clipper we have to scale them.
     private readonly PolygonClipper polygonClipper;
 
     /// <summary>
@@ -34,17 +31,17 @@ internal class Clipper
         FillRule fillRule = rule == IntersectionRule.EvenOdd ? FillRule.EvenOdd : FillRule.NonZero;
         this.polygonClipper.Execute(operation, fillRule, closedPaths, openPaths);
 
-        var shapes = new IPath[closedPaths.Count + openPaths.Count];
+        IPath[] shapes = new IPath[closedPaths.Count + openPaths.Count];
 
         int index = 0;
         for (int i = 0; i < closedPaths.Count; i++)
         {
             PathF path = closedPaths[i];
-            var points = new PointF[path.Count];
+            PointF[] points = new PointF[path.Count];
 
             for (int j = 0; j < path.Count; j++)
             {
-                points[j] = path[j] / ScalingFactor;
+                points[j] = path[j];
             }
 
             shapes[index++] = new Polygon(points);
@@ -53,11 +50,11 @@ internal class Clipper
         for (int i = 0; i < openPaths.Count; i++)
         {
             PathF path = openPaths[i];
-            var points = new PointF[path.Count];
+            PointF[] points = new PointF[path.Count];
 
             for (int j = 0; j < path.Count; j++)
             {
-                points[j] = path[j] / ScalingFactor;
+                points[j] = path[j];
             }
 
             shapes[index++] = new Polygon(points);
@@ -107,7 +104,7 @@ internal class Clipper
         PathF points = new(vectors.Length);
         for (int i = 0; i < vectors.Length; i++)
         {
-            points.Add((Vector2)vectors[i] * ScalingFactor);
+            points.Add(vectors[i]);
         }
 
         this.polygonClipper.AddPath(points, clippingType, !path.IsClosed);

--- a/src/ImageSharp.Drawing/Shapes/PolygonClipper/Clipper.cs
+++ b/src/ImageSharp.Drawing/Shapes/PolygonClipper/Clipper.cs
@@ -8,7 +8,6 @@ namespace SixLabors.ImageSharp.Drawing.Shapes.PolygonClipper;
 /// </summary>
 internal class Clipper
 {
-    // To make the floating point polygons compatible with clipper we have to scale them.
     private readonly PolygonClipper polygonClipper;
 
     /// <summary>

--- a/src/ImageSharp.Drawing/Shapes/Rasterization/ScanEdgeCollection.Build.cs
+++ b/src/ImageSharp.Drawing/Shapes/Rasterization/ScanEdgeCollection.Build.cs
@@ -98,7 +98,7 @@ internal partial class ScanEdgeCollection
                 if (verticesLength > 0)
                 {
                     ri = vertices.Length - (remainder / 2);
-                    float maxIterations = verticesLength / (Vector256<float>.Count * 2);
+                    nint maxIterations = verticesLength / (Vector256<float>.Count * 2);
                     ref Vector256<float> sourceBase = ref Unsafe.As<PointF, Vector256<float>>(ref MemoryMarshal.GetReference(vertices));
                     ref Vector256<float> destinationBase = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
 
@@ -136,7 +136,7 @@ internal partial class ScanEdgeCollection
                 if (verticesLength > 0)
                 {
                     ri = vertices.Length - (remainder / 2);
-                    float maxIterations = verticesLength / (Vector128<float>.Count * 2);
+                    nint maxIterations = verticesLength / (Vector128<float>.Count * 2);
                     ref Vector128<float> sourceBase = ref Unsafe.As<PointF, Vector128<float>>(ref MemoryMarshal.GetReference(vertices));
                     ref Vector128<float> destinationBase = ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(destination));
 
@@ -172,7 +172,7 @@ internal partial class ScanEdgeCollection
                 if (verticesLength > 0)
                 {
                     ri = vertices.Length - (remainder / 2);
-                    float maxIterations = verticesLength / (Vector128<float>.Count * 2);
+                    nint maxIterations = verticesLength / (Vector128<float>.Count * 2);
                     ref Vector128<float> sourceBase = ref Unsafe.As<PointF, Vector128<float>>(ref MemoryMarshal.GetReference(vertices));
                     ref Vector128<float> destinationBase = ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(destination));
 
@@ -186,7 +186,7 @@ internal partial class ScanEdgeCollection
                         Vector128<float> points1 = Unsafe.Add(ref sourceBase, j);
                         Vector128<float> points2 = Unsafe.Add(ref sourceBase, j + 1);
 
-                        // Shuffle the points to group the Y properties
+                        // Shuffle the points to group the Y
                         Vector128<float> pointsY = AdvSimdShuffle(points1, points2, 0b11_01_11_01);
 
                         // Multiply by the subsampling ratio, round, then multiply by the inverted subsampling ratio and assign.

--- a/tests/ImageSharp.Drawing.Benchmarks/Drawing/Rounding.cs
+++ b/tests/ImageSharp.Drawing.Benchmarks/Drawing/Rounding.cs
@@ -52,7 +52,7 @@ public class Rounding
             if (verticesLength > 0)
             {
                 ri = vertices.Length - (remainder / 2);
-                float maxIterations = verticesLength / (Vector256<float>.Count * 2);
+                nint maxIterations = verticesLength / (Vector256<float>.Count * 2);
                 ref Vector256<float> sourceBase = ref Unsafe.As<PointF, Vector256<float>>(ref MemoryMarshal.GetReference(vertices));
                 ref Vector256<float> destinationBase = ref Unsafe.As<float, Vector256<float>>(ref MemoryMarshal.GetReference(destination));
 
@@ -99,7 +99,7 @@ public class Rounding
             if (verticesLength > 0)
             {
                 ri = vertices.Length - (remainder / 2);
-                float maxIterations = verticesLength / (Vector128<float>.Count * 2);
+                nint maxIterations = verticesLength / (Vector128<float>.Count * 2);
                 ref Vector128<float> sourceBase = ref Unsafe.As<PointF, Vector128<float>>(ref MemoryMarshal.GetReference(vertices));
                 ref Vector128<float> destinationBase = ref Unsafe.As<float, Vector128<float>>(ref MemoryMarshal.GetReference(destination));
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds the missing commit from #290 
Removes unnecessary scaling from `PolygonClipper`.

<!-- Thanks for contributing to ImageSharp.Drawing! -->
