### PR TITLE
Fix arcs and do not throw when outlining

### DIFF
--- a/src/ImageSharp.Drawing/Shapes/PolygonClipper/BoundsF.cs
+++ b/src/ImageSharp.Drawing/Shapes/PolygonClipper/BoundsF.cs
@@ -14,9 +14,6 @@ internal struct BoundsF
 
     public BoundsF(float l, float t, float r, float b)
     {
-        Guard.MustBeGreaterThanOrEqualTo(r, l, nameof(r));
-        Guard.MustBeGreaterThanOrEqualTo(b, t, nameof(r));
-
         this.Left = l;
         this.Top = t;
         this.Right = r;

--- a/src/ImageSharp.Drawing/Shapes/PolygonClipper/PolygonOffsetter.cs
+++ b/src/ImageSharp.Drawing/Shapes/PolygonClipper/PolygonOffsetter.cs
@@ -99,10 +99,14 @@ internal sealed class PolygonOffsetter
             clipper.Execute(ClippingOperation.Union, FillRule.Positive, solution);
         }
 
-        // PolygonClipper will throw for unhandled exceptions but we need to explicitly capture an empty result.
+        // PolygonClipper will throw for unhandled exceptions but if a result is empty
+        // we should just return the original path.
         if (solution.Count == 0)
         {
-            throw new ClipperException("An error occurred while attempting to clip the polygon. Check input for invalid entries.");
+            foreach (PathF path in this.solution)
+            {
+                solution.Add(path);
+            }
         }
     }
 
@@ -213,9 +217,9 @@ internal sealed class PolygonOffsetter
                 }
                 else
                 {
-                    Vector2 d = new(MathF.Ceiling(this.groupDelta));
-                    Vector2 xy = path[0] - d;
-                    BoundsF r = new(xy.X, xy.Y, xy.X, xy.Y);
+                    float d = this.groupDelta;
+                    Vector2 xy = path[0];
+                    BoundsF r = new(xy.X - d, xy.Y - d, xy.X + d, xy.Y + d);
                     group.OutPath = r.AsPath();
                 }
 

--- a/tests/ImageSharp.Drawing.Tests/Drawing/DrawLinesTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/DrawLinesTests.cs
@@ -19,9 +19,34 @@ public class DrawLinesTests
         where TPixel : unmanaged, IPixel<TPixel>
     {
         Color color = TestUtils.GetColorByName(colorName).WithAlpha(alpha);
-        var pen = new SolidPen(color, thickness);
+        SolidPen pen = new(color, thickness);
 
         DrawLinesImpl(provider, colorName, alpha, thickness, antialias, pen);
+    }
+
+    [Theory]
+    [WithSolidFilledImages(30, 30, "White", PixelTypes.Rgba32, 1f, true)]
+    [WithSolidFilledImages(30, 30, "White", PixelTypes.Rgba32, 5f, true)]
+    [WithSolidFilledImages(30, 30, "White", PixelTypes.Rgba32, 1f, false)]
+    [WithSolidFilledImages(30, 30, "White", PixelTypes.Rgba32, 5f, false)]
+    public void DrawLinesInvalidPoints<TPixel>(TestImageProvider<TPixel> provider, float thickness, bool antialias)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        SolidPen pen = new(Color.Black, thickness);
+        PointF[] path = { new Vector2(15f, 15f), new Vector2(15f, 15f) };
+
+        GraphicsOptions options = new()
+        {
+            Antialias = antialias
+        };
+
+        string aa = antialias ? string.Empty : "_NoAntialias";
+        FormattableString outputDetails = $"T({thickness}){aa}";
+
+        provider.RunValidatingProcessorTest(
+            c => c.SetGraphicsOptions(options).DrawLine(pen, path),
+            outputDetails,
+            appendSourceFileOrDescription: false);
     }
 
     [Theory]
@@ -74,7 +99,7 @@ public class DrawLinesTests
         where TPixel : unmanaged, IPixel<TPixel>
     {
         Color color = TestUtils.GetColorByName(colorName).WithAlpha(alpha);
-        PatternPen pen = new PatternPen(new PenOptions(color, thickness, new float[] { 3f, 3f }) { EndCapStyle = EndCapStyle.Round });
+        PatternPen pen = new(new PenOptions(color, thickness, new float[] { 3f, 3f }) { EndCapStyle = EndCapStyle.Round });
 
         DrawLinesImpl(provider, colorName, alpha, thickness, antialias, pen);
     }
@@ -85,7 +110,7 @@ public class DrawLinesTests
 where TPixel : unmanaged, IPixel<TPixel>
     {
         Color color = TestUtils.GetColorByName(colorName).WithAlpha(alpha);
-        PatternPen pen = new PatternPen(new PenOptions(color, thickness, new float[] { 3f, 3f }) { EndCapStyle = EndCapStyle.Butt });
+        PatternPen pen = new(new PenOptions(color, thickness, new float[] { 3f, 3f }) { EndCapStyle = EndCapStyle.Butt });
 
         DrawLinesImpl(provider, colorName, alpha, thickness, antialias, pen);
     }
@@ -96,7 +121,7 @@ where TPixel : unmanaged, IPixel<TPixel>
 where TPixel : unmanaged, IPixel<TPixel>
     {
         Color color = TestUtils.GetColorByName(colorName).WithAlpha(alpha);
-        PatternPen pen = new PatternPen(new PenOptions(color, thickness, new float[] { 3f, 3f }) { EndCapStyle = EndCapStyle.Square });
+        PatternPen pen = new(new PenOptions(color, thickness, new float[] { 3f, 3f }) { EndCapStyle = EndCapStyle.Square });
 
         DrawLinesImpl(provider, colorName, alpha, thickness, antialias, pen);
     }
@@ -107,7 +132,7 @@ where TPixel : unmanaged, IPixel<TPixel>
 where TPixel : unmanaged, IPixel<TPixel>
     {
         Color color = TestUtils.GetColorByName(colorName).WithAlpha(alpha);
-        var pen = new SolidPen(new PenOptions(color, thickness) { JointStyle = JointStyle.Round });
+        SolidPen pen = new(new PenOptions(color, thickness) { JointStyle = JointStyle.Round });
 
         DrawLinesImpl(provider, colorName, alpha, thickness, antialias, pen);
     }
@@ -118,7 +143,7 @@ where TPixel : unmanaged, IPixel<TPixel>
 where TPixel : unmanaged, IPixel<TPixel>
     {
         Color color = TestUtils.GetColorByName(colorName).WithAlpha(alpha);
-        var pen = new SolidPen(new PenOptions(color, thickness) { JointStyle = JointStyle.Square });
+        SolidPen pen = new(new PenOptions(color, thickness) { JointStyle = JointStyle.Square });
 
         DrawLinesImpl(provider, colorName, alpha, thickness, antialias, pen);
     }
@@ -129,7 +154,7 @@ where TPixel : unmanaged, IPixel<TPixel>
 where TPixel : unmanaged, IPixel<TPixel>
     {
         Color color = TestUtils.GetColorByName(colorName).WithAlpha(alpha);
-        var pen = new SolidPen(new PenOptions(color, thickness) { JointStyle = JointStyle.Miter });
+        SolidPen pen = new(new PenOptions(color, thickness) { JointStyle = JointStyle.Miter });
 
         DrawLinesImpl(provider, colorName, alpha, thickness, antialias, pen);
     }
@@ -145,7 +170,8 @@ where TPixel : unmanaged, IPixel<TPixel>
     {
         PointF[] simplePath = { new Vector2(10, 10), new Vector2(200, 150), new Vector2(50, 300) };
 
-        var options = new GraphicsOptions { Antialias = antialias };
+        GraphicsOptions options = new()
+        { Antialias = antialias };
 
         string aa = antialias ? string.Empty : "_NoAntialias";
         FormattableString outputDetails = $"{colorName}_A({alpha})_T({thickness}){aa}";

--- a/tests/ImageSharp.Drawing.Tests/Drawing/DrawPathTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/DrawPathTests.cs
@@ -26,20 +26,20 @@ public class DrawPathTests
     public void DrawPath<TPixel>(TestImageProvider<TPixel> provider, string colorName, byte alpha, float thickness)
         where TPixel : unmanaged, IPixel<TPixel>
     {
-        var linearSegment = new LinearLineSegment(
+        LinearLineSegment linearSegment = new(
             new Vector2(10, 10),
             new Vector2(200, 150),
             new Vector2(50, 300));
-        var bezierSegment = new CubicBezierLineSegment(
+        CubicBezierLineSegment bezierSegment = new(
             new Vector2(50, 300),
             new Vector2(500, 500),
             new Vector2(60, 10),
             new Vector2(10, 400));
 
-        var ellipticArcSegment1 = new ArcLineSegment(new Vector2(10, 400), new Vector2(150, 450), new SizeF((float)Math.Sqrt(5525), 40), GeometryUtilities.RadianToDegree((float)Math.Atan2(25, 70)), true, true);
-        var ellipticArcSegment2 = new ArcLineSegment(new(150, 450), new(149F, 450), new SizeF(140, 70), 0, true, true);
+        ArcLineSegment ellipticArcSegment1 = new(new Vector2(10, 400), new Vector2(150, 450), new SizeF((float)Math.Sqrt(5525), 40), GeometryUtilities.RadianToDegree((float)Math.Atan2(25, 70)), true, true);
+        ArcLineSegment ellipticArcSegment2 = new(new(150, 450), new(149F, 450), new SizeF(140, 70), 0, true, true);
 
-        var path = new Path(linearSegment, bezierSegment, ellipticArcSegment1, ellipticArcSegment2);
+        Path path = new(linearSegment, bezierSegment, ellipticArcSegment1, ellipticArcSegment2);
 
         Rgba32 rgba = TestUtils.GetColorByName(colorName);
         rgba.A = alpha;
@@ -67,7 +67,7 @@ public class DrawPathTests
                 {
                     for (int i = 0; i < 300; i += 20)
                     {
-                        var points = new PointF[] { new Vector2(100, 2), new Vector2(-10, i) };
+                        PointF[] points = new PointF[] { new Vector2(100, 2), new Vector2(-10, i) };
                         x.DrawLine(pen, points);
                     }
                 },
@@ -91,7 +91,38 @@ public class DrawPathTests
 
         provider.VerifyOperation(
             image => image.Mutate(x => x.Draw(Color.Black, 1, path)),
-            appendSourceFileOrDescription: false,
-            appendPixelTypeToFileName: false);
+            appendPixelTypeToFileName: false,
+            appendSourceFileOrDescription: false);
+    }
+
+    [Theory]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 360)]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 359)]
+    public void DrawCircleUsingAddArc<TPixel>(TestImageProvider<TPixel> provider, float sweep)
+    where TPixel : unmanaged, IPixel<TPixel>
+    {
+        IPath path = new PathBuilder().AddArc(new Point(150, 150), 50, 50, 0, 40, sweep).Build();
+
+        provider.VerifyOperation(
+            image => image.Mutate(x => x.Draw(Color.Black, 1, path)),
+            testOutputDetails: $"{sweep}",
+            appendPixelTypeToFileName: false,
+            appendSourceFileOrDescription: false);
+    }
+
+    [Theory]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, true)]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, false)]
+    public void DrawCircleUsingArcTo<TPixel>(TestImageProvider<TPixel> provider, bool sweep)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        Point origin = new(150, 150);
+        IPath path = new PathBuilder().MoveTo(origin).ArcTo(50, 50, 0, true, sweep, origin).Build();
+
+        provider.VerifyOperation(
+            image => image.Mutate(x => x.Draw(Color.Black, 1, path)),
+            testOutputDetails: $"{sweep}",
+            appendPixelTypeToFileName: false,
+            appendSourceFileOrDescription: false);
     }
 }

--- a/tests/ImageSharp.Drawing.Tests/Shapes/PolygonClipper/ClipperTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/PolygonClipper/ClipperTests.cs
@@ -130,13 +130,4 @@ public class ClipperTests
 
         Assert.Equal(8, points.Count);
     }
-
-    [Fact]
-    public void ClipperOffsetThrowsPublicException()
-    {
-        PointF naan = new(float.NaN, float.NaN);
-        Polygon path = new(new LinearLineSegment(new[] { naan, naan, naan, naan }));
-
-        Assert.Throws<ClipperException>(() => path.GenerateOutline(10));
-    }
 }

--- a/tests/Images/ReferenceOutput/Drawing/DrawLinesTests/DrawLinesInvalidPoints_Rgba32_T(1).png
+++ b/tests/Images/ReferenceOutput/Drawing/DrawLinesTests/DrawLinesInvalidPoints_Rgba32_T(1).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:459dcb4b0e81dc7e850babc169510ac2298636c7a65c06802f104dca3ce87a45
+size 165

--- a/tests/Images/ReferenceOutput/Drawing/DrawLinesTests/DrawLinesInvalidPoints_Rgba32_T(1)_NoAntialias.png
+++ b/tests/Images/ReferenceOutput/Drawing/DrawLinesTests/DrawLinesInvalidPoints_Rgba32_T(1)_NoAntialias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d2ab1c8fd901a5bede28a3036a4df9cb551e6a13c154a988da1700c89fb67b4
+size 161

--- a/tests/Images/ReferenceOutput/Drawing/DrawLinesTests/DrawLinesInvalidPoints_Rgba32_T(5).png
+++ b/tests/Images/ReferenceOutput/Drawing/DrawLinesTests/DrawLinesInvalidPoints_Rgba32_T(5).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:635053b4ce23dafc080d4d9de9e808819d264461ee5e0543acfefb8c9a04d00e
+size 187

--- a/tests/Images/ReferenceOutput/Drawing/DrawLinesTests/DrawLinesInvalidPoints_Rgba32_T(5)_NoAntialias.png
+++ b/tests/Images/ReferenceOutput/Drawing/DrawLinesTests/DrawLinesInvalidPoints_Rgba32_T(5)_NoAntialias.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5482537fd9d8f4ad4c6e03ae1ae0d7f8035ecb29f541778009653ab7796510dd
+size 173

--- a/tests/Images/ReferenceOutput/Drawing/DrawPathTests/DrawCircleUsingAddArc_359.png
+++ b/tests/Images/ReferenceOutput/Drawing/DrawPathTests/DrawCircleUsingAddArc_359.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b48a33ee84606f1b74ebb1fe047df7eedd8a36758a17860d04b2b11a2116e55
+size 3927

--- a/tests/Images/ReferenceOutput/Drawing/DrawPathTests/DrawCircleUsingAddArc_360.png
+++ b/tests/Images/ReferenceOutput/Drawing/DrawPathTests/DrawCircleUsingAddArc_360.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30d023cfe508a969b3386dfaea3b1b30be935ee932f3e57df705b966c93ef341
+size 3930

--- a/tests/Images/ReferenceOutput/Drawing/DrawPathTests/DrawCircleUsingArcTo_False.png
+++ b/tests/Images/ReferenceOutput/Drawing/DrawPathTests/DrawCircleUsingArcTo_False.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9eadf653708a1d8031e543f17cdea79140792140cce59444979aeccf32a8d983
+size 4148

--- a/tests/Images/ReferenceOutput/Drawing/DrawPathTests/DrawCircleUsingArcTo_True.png
+++ b/tests/Images/ReferenceOutput/Drawing/DrawPathTests/DrawCircleUsingArcTo_True.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b752270cb16a191a1868fc91a7a11806f1138259846954ca05ea5c937ece301a
+size 3571


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #299, #300

The way I was handling arc generation when the arc sweep represented a closed ellipse didn't take into consideration the start angle. 

Fixing the issue meant that we threw during outlining when someone requested the short arc so I fixed the offsetter to return the unclipped path I also fixed the handling of paths containing a single point. 

<!-- Thanks for contributing to ImageSharp.Drawing! -->
