### PR TITLE
Fix Out of Bounds Text Drawing

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/DrawTextProcessor{TPixel}.cs
@@ -99,7 +99,7 @@ internal class DrawTextProcessor<TPixel> : ImageProcessor<TPixel>
                 for (int row = firstRow; row < end; row++)
                 {
                     int y = startY + row;
-                    Span<float> span = buffer.DangerousGetRowSpan(row)[offsetSpan..];
+                    Span<float> span = buffer.DangerousGetRowSpan(row).Slice(offsetSpan, Math.Min(buffer.Width - offsetSpan, source.Width));
                     app.Apply(span, startX, y);
                 }
             }

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRenderTextOutOfBoundsIssue301.png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRenderTextOutOfBoundsIssue301.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0667e1476a91a4bc4e7ee91ef52d213986ac46dcc942fa2874c3cb60c24229bd
+size 1321


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fixes #301 

The `DrawTextProcessor` allowed rendered buffers that exceeded the width of the image frame. This PR clamps the length of the span passed to the brush applicator. Our other processors correctly limit the span length.

I also added colorstop stable sorting to the gradient brush since I spotted the TODO while debugging.

<!-- Thanks for contributing to ImageSharp.Drawing! -->
