### PR TITLE
Mitigate issue where outline thicknesses less than 0.5 fail out generate solid shapes not outlines

### DIFF
--- a/tests/ImageSharp.Drawing.Tests/Issues/Issue_323.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issue_323.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Drawing.Tests.Issues;
+
+public class Issue_323
+{
+    [Theory]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 3f)]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 1f)]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 0.3f)]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 0.7f)]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 0.003f)]
+    public void DrawPolygonMustDrawoutlineOnly<TPixel>(TestImageProvider<TPixel> provider, float scale)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        Color color = Color.RebeccaPurple;
+        provider.RunValidatingProcessorTest(
+            x => x.DrawPolygon(
+                color,
+                scale,
+                new PointF[] {
+                    new(5, 5),
+                    new(5, 150),
+                    new(190, 150),
+                }),
+            new { scale });
+    }
+
+    [Theory]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 3f)]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 1f)]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 0.3f)]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 0.7f)]
+    [WithSolidFilledImages(300, 300, "White", PixelTypes.Rgba32, 0.003f)]
+    public void DrawPolygonMustDrawoutlineOnly_Pattern<TPixel>(TestImageProvider<TPixel> provider, float scale)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        Color color = Color.RebeccaPurple;
+        var pen = Pens.DashDot(color, scale);
+        provider.RunValidatingProcessorTest(
+                    x => x.DrawPolygon(
+                      pen,
+                      new PointF[] {
+                            new(5, 5),
+                            new(5, 150),
+                            new(190, 150),
+                        }),
+                    new { scale });
+    }
+}

--- a/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Pattern_Rgba32_Solid300x300_(255,255,255,255)_scale-0.003.png
+++ b/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Pattern_Rgba32_Solid300x300_(255,255,255,255)_scale-0.003.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc86c51ad4946fb8a314c8d869a83cc2496d30468036729c3827c2c121cae69c
+size 1068

--- a/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Pattern_Rgba32_Solid300x300_(255,255,255,255)_scale-0.3.png
+++ b/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Pattern_Rgba32_Solid300x300_(255,255,255,255)_scale-0.3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62f86685f6f2326e629b8b84340bb1b3cbcf6ffe75facff0931b613337772345
+size 3296

--- a/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Pattern_Rgba32_Solid300x300_(255,255,255,255)_scale-0.7.png
+++ b/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Pattern_Rgba32_Solid300x300_(255,255,255,255)_scale-0.7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:534d3fece38b94386b6ba20aa121addda1beea61d38cb34b9d2ae09b662fd38b
+size 3585

--- a/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Pattern_Rgba32_Solid300x300_(255,255,255,255)_scale-1.png
+++ b/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Pattern_Rgba32_Solid300x300_(255,255,255,255)_scale-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fff4ab1fec04c432529fd67d9c50934ce083fa6e7c0c4432fd6520eac2e53ac
+size 3625

--- a/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Pattern_Rgba32_Solid300x300_(255,255,255,255)_scale-3.png
+++ b/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Pattern_Rgba32_Solid300x300_(255,255,255,255)_scale-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92a356847e8aa36b361a2208021a0c0e2a3287d615f0b948bdbcc0bc3b336bc4
+size 4300

--- a/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Rgba32_Solid300x300_(255,255,255,255)_scale-0.003.png
+++ b/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Rgba32_Solid300x300_(255,255,255,255)_scale-0.003.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b02efd026d5ed83d1e0e747c8675d340bda7ba246d5a9385ecc6dabc81861e0
+size 3015

--- a/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Rgba32_Solid300x300_(255,255,255,255)_scale-0.3.png
+++ b/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Rgba32_Solid300x300_(255,255,255,255)_scale-0.3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f02d5a40abd8bbef39f2648f2d40d5da5a28adfbc5b015a56641eef5fb50de05
+size 3050

--- a/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Rgba32_Solid300x300_(255,255,255,255)_scale-0.7.png
+++ b/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Rgba32_Solid300x300_(255,255,255,255)_scale-0.7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11b915b55e0005b52bf80e4891f293b6cb6477f3e0d83fead71768ac359fa610
+size 3382

--- a/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Rgba32_Solid300x300_(255,255,255,255)_scale-1.png
+++ b/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Rgba32_Solid300x300_(255,255,255,255)_scale-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a48c33c58c36ba7f581fe7d60eaf0bbc96948640b14ccbdd891adeae031a7ad
+size 3691

--- a/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Rgba32_Solid300x300_(255,255,255,255)_scale-3.png
+++ b/tests/Images/ReferenceOutput/Issue_323/DrawPolygonMustDrawoutlineOnly_Rgba32_Solid300x300_(255,255,255,255)_scale-3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e80954c53985fc65b0846778861e3c023a8c798d466be887545fe2438ab5e3a3
+size 4353


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
If the outline thickness is going to trigger the noop behaviour of the clipper then scale the inputs and outputs to not trigger that behaviour.

I tried just removing the test in [`PolygonOffsetter.cs`](https://github.com/SixLabors/ImageSharp.Drawing/blob/2a9ee5150addbf280801ed25392a8ec29eb8e263/src/ImageSharp.Drawing/Shapes/PolygonClipper/PolygonOffsetter.cs#L121) but for some reason  that causes very small outlines to take significantly longer to generate than scaling up and down. (not investigated why).

This causes everything to generally render now, what it renders at particularly small sizes might not be the best (not investigated) but at least we generally render something better than the solid shape.

resolves #323 
<!-- Thanks for contributing to ImageSharp.Drawing! -->
