### PR TITLE
Update Fonts to v2.0.3 and ImageSharp to v3.1.4

### DIFF
--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -45,8 +45,8 @@
     <None Include="..\..\shared-infrastructure\branding\icons\imagesharp.drawing\sixlabors.imagesharp.drawing.128.png" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="2.0.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
+    <PackageReference Include="SixLabors.Fonts" Version="2.0.3" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
   </ItemGroup>
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />
 </Project>

--- a/tests/ImageSharp.Drawing.Tests/Drawing/Text/DrawTextOnImageTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Drawing/Text/DrawTextOnImageTests.cs
@@ -451,8 +451,8 @@ public class DrawTextOnImageTests
         AffineTransformBuilder builder = new AffineTransformBuilder().AppendRotationDegrees(angle);
 
         RichTextOptions textOptions = new(font);
-        FontRectangle bounds = TextMeasurer.MeasureSize(text, textOptions);
-        Matrix3x2 transform = builder.BuildMatrix(Rectangle.Round(new RectangleF(bounds.X, bounds.Y, bounds.Width, bounds.Height)));
+        FontRectangle advance = TextMeasurer.MeasureAdvance(text, textOptions);
+        Matrix3x2 transform = builder.BuildMatrix(Rectangle.Round(new RectangleF(advance.X, advance.Y, advance.Width, advance.Height)));
 
         provider.RunValidatingProcessorTest(
             x => x.SetDrawingTransform(transform).DrawText(textOptions, text, Color.Black),
@@ -478,8 +478,8 @@ public class DrawTextOnImageTests
         AffineTransformBuilder builder = new AffineTransformBuilder().AppendRotationDegrees(angle);
 
         RichTextOptions textOptions = new(font);
-        FontRectangle bounds = TextMeasurer.MeasureSize(text, textOptions);
-        Matrix3x2 transform = builder.BuildMatrix(Rectangle.Round(new RectangleF(bounds.X, bounds.Y, bounds.Width, bounds.Height)));
+        FontRectangle advance = TextMeasurer.MeasureAdvance(text, textOptions);
+        Matrix3x2 transform = builder.BuildMatrix(Rectangle.Round(new RectangleF(advance.X, advance.Y, advance.Width, advance.Height)));
 
         provider.RunValidatingProcessorTest(
             x => x.SetDrawingTransform(transform)

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateFilledFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(32)-A(75)-Quic).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateFilledFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(32)-A(75)-Quic).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb5b0018f8b464e389379b3b50c89e941d49eec211107b5ddbbfad10c49d14ad
-size 2011
+oid sha256:9ff9565be8de6cab9694b59a0722e1749685f67a4f2e3db9f9be86390098c16f
+size 1968

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateFilledFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(40)-A(90)-Quic).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateFilledFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(40)-A(90)-Quic).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:49926d3e7aeb9043d3e64d251409963f4bc0022eb8fe2a5495c46125efa30a7e
-size 1769
+oid sha256:9dc2980efa5b3ad73139d98e88f2fb0fc6f0e0a2e1153009f36de253386b773b
+size 1709

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateOutlineFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(32)-A(75)-STR(1)-Quic).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateOutlineFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(32)-A(75)-STR(1)-Quic).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:071dcbc4215ad9e67f12cd3cca802c09ca94c536e3214665c215e8732cf3a5c4
-size 2667
+oid sha256:ce6a7b5ca590a8594fe215e8b15e9f22c57644df9aa5770d7434755019fdc679
+size 2608

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateOutlineFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(40)-A(90)-STR(2)-Quic).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateOutlineFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(40)-A(90)-STR(2)-Quic).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b144e75360ba2b70a532e323210e519795c91942532e4ac992af1b04b06ad72
-size 2510
+oid sha256:4396a75b759dad700ae08df7549df0ab35f2ae154a948eca5bb51710490f0d83
+size 2447


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to ImageSharp.Drawing! -->
