### PR TITLE
Align font outline and fill while calling DrawText

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,7 @@ jobs:
             sdk-preview: true
             runtime: -x64
             codecov: false
-          - os: macos-latest
+          - os: macos-13 # macos-latest runs on arm64 runners where libgdiplus is unavailable
             framework: net7.0
             sdk: 7.0.x
             sdk-preview: true
@@ -46,7 +46,7 @@ jobs:
             sdk: 6.0.x
             runtime: -x64
             codecov: false
-          - os: macos-latest
+          - os: macos-13 # macos-latest runs on arm64 runners where libgdiplus is unavailable
             framework: net6.0
             sdk: 6.0.x
             runtime: -x64

--- a/src/ImageSharp.Drawing/Processing/Processors/Text/RichTextGlyphRenderer.cs
+++ b/src/ImageSharp.Drawing/Processing/Processors/Text/RichTextGlyphRenderer.cs
@@ -367,9 +367,10 @@ internal sealed class RichTextGlyphRenderer : BaseGlyphBuilder, IColorGlyphRende
 
         if (renderData.OutlineMap != null)
         {
+            int offset = (int)((this.currentPen?.StrokeWidth ?? 0) / 2);
             this.DrawingOperations.Add(new DrawingOperation
             {
-                RenderLocation = renderLocation,
+                RenderLocation = renderLocation - new Size(offset, offset),
                 Map = renderData.OutlineMap,
                 Brush = this.currentPen?.StrokeFill ?? this.currentBrush!,
                 RenderPass = RenderOrderOutline

--- a/tests/ImageSharp.Drawing.Tests/Issues/Issue_330.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issue_330.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Drawing.Tests.Issues;
+public class Issue_330
+{
+    [Theory]
+    [WithSolidFilledImages(2084, 2084, nameof(Color.BlueViolet), PixelTypes.Rgba32)]
+    public void OffsetTextOutlines<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        FontFamily fontFamily = TestFontUtilities.GetFontFamily(TestFonts.OpenSans);
+
+        Font bibfont = fontFamily.CreateFont(600, FontStyle.Bold);
+        Font namefont = fontFamily.CreateFont(140, FontStyle.Bold);
+
+        provider.RunValidatingProcessorTest(p =>
+        {
+            p.DrawText(
+                new RichTextOptions(bibfont)
+                {
+                    VerticalAlignment = VerticalAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    TextAlignment = TextAlignment.Center,
+                    TextDirection = TextDirection.LeftToRight,
+                    Origin = new Point(1156, 1024),
+                },
+                "9999",
+                Brushes.Solid(Color.White),
+                Pens.Solid(Color.Black, 20));
+
+            p.DrawText(
+                new RichTextOptions(namefont)
+                {
+                    VerticalAlignment = VerticalAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    TextAlignment = TextAlignment.Center,
+                    TextDirection = TextDirection.LeftToRight,
+                    Origin = new Point(1156, 713),
+                },
+                "JOHAN",
+                Brushes.Solid(Color.White),
+                Pens.Solid(Color.Black, 5));
+
+            p.DrawText(
+                new RichTextOptions(namefont)
+                {
+                    VerticalAlignment = VerticalAlignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    TextAlignment = TextAlignment.Center,
+                    TextDirection = TextDirection.LeftToRight,
+                    Origin = new Point(1156, 1381),
+                },
+                "TIGERTECH",
+                Brushes.Solid(Color.White),
+                Pens.Solid(Color.Black, 5));
+        });
+    }
+}

--- a/tests/ImageSharp.Drawing.Tests/Issues/Issue_330.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issue_330.cs
@@ -14,7 +14,7 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Issues;
 public class Issue_330
 {
     [Theory]
-    [WithSolidFilledImages(2084, 2084, nameof(Color.BlueViolet), PixelTypes.Rgba32)]
+    [WithSolidFilledImages(2084, 2084, "BlueViolet", PixelTypes.Rgba32)]
     public void OffsetTextOutlines<TPixel>(TestImageProvider<TPixel> provider)
         where TPixel : unmanaged, IPixel<TPixel>
     {

--- a/tests/ImageSharp.Drawing.Tests/TestFontUtilities.cs
+++ b/tests/ImageSharp.Drawing.Tests/TestFontUtilities.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Globalization;
 using System.Reflection;
 using SixLabors.Fonts;
 using IOPath = System.IO.Path;
@@ -19,7 +20,15 @@ public static class TestFontUtilities
     /// <param name="size">The font size.</param>
     /// <returns>The <see cref="Font"/></returns>
     public static Font GetFont(string name, float size)
-        => GetFont(new FontCollection(), name, size);
+        => GetFontFamily(name).CreateFont(size);
+
+    /// <summary>
+    /// Gets a font family with the given name.
+    /// </summary>
+    /// <param name="name">The name of the font.</param>
+    /// <returns>The <see cref="Font"/></returns>
+    public static FontFamily GetFontFamily(string name)
+        => GetFontFamily(new FontCollection(), name);
 
     /// <summary>
     /// Gets a font with the given name and size.
@@ -29,7 +38,16 @@ public static class TestFontUtilities
     /// <param name="size">The font size.</param>
     /// <returns>The <see cref="Font"/></returns>
     public static Font GetFont(FontCollection collection, string name, float size)
-        => collection.Add(GetPath(name)).CreateFont(size);
+        => GetFontFamily(collection, name).CreateFont(size);
+
+    /// <summary>
+    /// Gets a font family with the given name
+    /// </summary>
+    /// <param name="collection">The collection to add the font to</param>
+    /// <param name="name">The name of the font.</param>
+    /// <returns>The <see cref="Font"/></returns>
+    public static FontFamily GetFontFamily(FontCollection collection, string name)
+        => collection.Add(GetPath(name), CultureInfo.InvariantCulture);
 
     /// <summary>
     /// The formats directory.

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateOutlineFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(40)-A(90)-STR(2)-Quic).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateOutlineFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(40)-A(90)-STR(2)-Quic).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4396a75b759dad700ae08df7549df0ab35f2ae154a948eca5bb51710490f0d83
-size 2447
+oid sha256:c00599c79b059fa60e52b7de3a52d574c677df2c2a9729c3a046f75059583e27
+size 6023

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectlyWithAPenPatterned_Solid1100x200_(255,255,255,255)_pen_OpenSans-Regular.ttf-50-Sphi-(150,50).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectlyWithAPenPatterned_Solid1100x200_(255,255,255,255)_pen_OpenSans-Regular.ttf-50-Sphi-(150,50).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:450d4edb2b067c212705387ea6a42763464707c86d0ddd365b81c1795ad31c93
-size 17917
+oid sha256:8333f5bf72363f6cbebd69efe351d4234ae7f870b5c088991bd0a18ee855aa30
+size 33277

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectlyWithAPenPatterned_Solid200x150_(255,255,255,255)_pen_SixLaborsSampleAB.woff-50-ABAB-(0,0).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectlyWithAPenPatterned_Solid200x150_(255,255,255,255)_pen_SixLaborsSampleAB.woff-50-ABAB-(0,0).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb97d53d830d65c290158ce1bbd5eae4033727f8fe8b534b7555c4bde89c9db0
-size 1244
+oid sha256:74bc71359f75ab560474d53aa74d2e4a4d09807552020d426e6f1545b769b71b
+size 2821

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectlyWithAPenPatterned_Solid900x150_(255,255,255,255)_pen_OpenSans-Regular.ttf-50-Sphi-(0,0).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FontShapesAreRenderedCorrectlyWithAPenPatterned_Solid900x150_(255,255,255,255)_pen_OpenSans-Regular.ttf-50-Sphi-(0,0).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65702ca76b6301fa1c4c1ecf4b07e654de1a4a59940ed156fc91d8670cf4c56a
-size 17366
+oid sha256:3ffcef97021e6572d9827ac1a128882042695bf2b3bf1e27127358d7cef994f6
+size 31488

--- a/tests/Images/ReferenceOutput/Issue_330/OffsetTextOutlines_Rgba32_Solid2084x2084_(138,43,226,255).png
+++ b/tests/Images/ReferenceOutput/Issue_330/OffsetTextOutlines_Rgba32_Solid2084x2084_(138,43,226,255).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b44ee8f82a88b7a6d8c0c908308aac7c9d90ad22370e2942b976c06cbdf2f1b3
+size 186486


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
fixes the outline being offset from the fill.
Required the outline being moved (thickness/2) pixels up and left.

## before
![image](https://github.com/SixLabors/ImageSharp.Drawing/assets/166440/9177a9cf-4e8a-4da5-a927-c9346f76013d)

## after
![image](https://github.com/SixLabors/ImageSharp.Drawing/assets/166440/486a262b-c8ee-48d3-bce4-327e0c3c7360)

fixes #330
