### PR TITLE
Update references and fix casting of RichTextRuns

### DIFF
--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -45,8 +45,8 @@
     <None Include="..\..\shared-infrastructure\branding\icons\imagesharp.drawing\sixlabors.imagesharp.drawing.128.png" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="2.0.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+    <PackageReference Include="SixLabors.Fonts" Version="2.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
   </ItemGroup>
   <Import Project="..\..\shared-infrastructure\src\SharedInfrastructure\SharedInfrastructure.projitems" Label="Shared" />
 </Project>

--- a/src/ImageSharp.Drawing/Processing/RichTextOptions.cs
+++ b/src/ImageSharp.Drawing/Processing/RichTextOptions.cs
@@ -16,8 +16,7 @@ public class RichTextOptions : TextOptions
     /// <param name="font">The font.</param>
     public RichTextOptions(Font font)
         : base(font)
-    {
-    }
+        => this.TextRuns = Array.Empty<RichTextRun>();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RichTextOptions" /> class from properties

--- a/tests/ImageSharp.Drawing.Tests/Issues/Issue_332.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issue_332.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.Fonts;
+using SixLabors.ImageSharp.Drawing.Processing;
+
+namespace SixLabors.ImageSharp.Drawing.Tests.Issues;
+
+public class Issue_332
+{
+    [Fact]
+    public void CanAccessEmptyRichTextRuns()
+    {
+        Font font = TestFontUtilities.GetFont(TestFonts.OpenSans, 70);
+        RichTextOptions options = new(font);
+        Assert.Empty(options.TextRuns);
+    }
+}

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateFilledFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(32)-A(75)-Quic).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateFilledFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(32)-A(75)-Quic).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ff9565be8de6cab9694b59a0722e1749685f67a4f2e3db9f9be86390098c16f
-size 1968
+oid sha256:a519106bb39b4ec9c569fe43cb0c63ef46808c29ffb3f172b4db9a93f4faf9f4
+size 1962

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateFilledFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(40)-A(90)-Quic).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateFilledFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(40)-A(90)-Quic).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9dc2980efa5b3ad73139d98e88f2fb0fc6f0e0a2e1153009f36de253386b773b
-size 1709
+oid sha256:bde19b36b56e7974c47c459183210589ced41b93bd9fcd0ba22b4baabaac2176
+size 1704

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateOutlineFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(32)-A(75)-STR(1)-Quic).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateOutlineFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(32)-A(75)-STR(1)-Quic).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce6a7b5ca590a8594fe215e8b15e9f22c57644df9aa5770d7434755019fdc679
-size 2608
+oid sha256:82fd62a3b4080137e31a23a4485b467b2804313fb57455017f1ef11de1d38e5e
+size 2595

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateOutlineFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(40)-A(90)-STR(2)-Quic).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/CanRotateOutlineFont_Issue175_Solid300x200_(255,255,255,255)_F(OpenSans-Regular.ttf)-S(40)-A(90)-STR(2)-Quic).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c00599c79b059fa60e52b7de3a52d574c677df2c2a9729c3a046f75059583e27
-size 6023
+oid sha256:f9e7f3f9aabf29e053e05eb4e4f7c3114e58d6229e9539aa566e42a19a775b90
+size 2430

--- a/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FallbackFontRendering_Rgba32_Solid400x200_(255,255,255,255).png
+++ b/tests/Images/ReferenceOutput/Drawing/Text/DrawTextOnImageTests/FallbackFontRendering_Rgba32_Solid400x200_(255,255,255,255).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:460ab85bf88b181f95fcfc5f029f826d2781aa56f6e770e676e1c7a0e0f02f11
-size 1819
+oid sha256:6fdc4f70e69b94796a45ee83c6d79c7e1d3bca364ca164fa2c9bcd38f40b2664
+size 1783


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
ImageSharp v3.1.5
Fonts v2.0.4

<!-- Thanks for contributing to ImageSharp.Drawing! -->
