### PR TITLE
RecolorBrush  - Limit access to target dimensions

### DIFF
--- a/ImageSharp.Drawing.sln
+++ b/ImageSharp.Drawing.sln
@@ -28,7 +28,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEMPLATE", "{FBE8C1AD-5AEC-4514-9B64-091D8E145865}"
 	ProjectSection(SolutionItems) = preProject
 		.github\ISSUE_TEMPLATE\config.yml = .github\ISSUE_TEMPLATE\config.yml
-		.github\ISSUE_TEMPLATE\oss-bug-report.md = .github\ISSUE_TEMPLATE\oss-bug-report.md
+		.github\ISSUE_TEMPLATE\oss-bug-report.yml = .github\ISSUE_TEMPLATE\oss-bug-report.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{815C0625-CD3D-440F-9F80-2D83856AB7AE}"

--- a/src/ImageSharp.Drawing/Processing/RecolorBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/RecolorBrush.cs
@@ -136,9 +136,17 @@ public sealed class RecolorBrush : Brush
         /// <inheritdoc />
         public override void Apply(Span<float> scanline, int x, int y)
         {
-            Span<float> amounts = this.blenderBuffers.AmountSpan.Slice(0, scanline.Length);
-            Span<TPixel> overlays = this.blenderBuffers.OverlaySpan.Slice(0, scanline.Length);
+            if (x < 0 || y < 0 || x >= this.Target.Width || y >= this.Target.Height)
+            {
+                return;
+            }
 
+            // Limit the scanline to the bounds of the image relative to x.
+            scanline = scanline[..Math.Min(this.Target.Width - x, scanline.Length)];
+            Span<float> amounts = this.blenderBuffers.AmountSpan[..scanline.Length];
+            Span<TPixel> overlays = this.blenderBuffers.OverlaySpan[..scanline.Length];
+
+            int width = this.Target.Width;
             for (int i = 0; i < scanline.Length; i++)
             {
                 amounts[i] = scanline[i] * this.Options.BlendPercentage;

--- a/src/ImageSharp.Drawing/Processing/RecolorBrush.cs
+++ b/src/ImageSharp.Drawing/Processing/RecolorBrush.cs
@@ -146,7 +146,6 @@ public sealed class RecolorBrush : Brush
             Span<float> amounts = this.blenderBuffers.AmountSpan[..scanline.Length];
             Span<TPixel> overlays = this.blenderBuffers.OverlaySpan[..scanline.Length];
 
-            int width = this.Target.Width;
             for (int i = 0; i < scanline.Length; i++)
             {
                 amounts[i] = scanline[i] * this.Options.BlendPercentage;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
RecolorBrush didn't take transforms into consideration. I've not added an explicit test but here's the output from the samples project.

<!-- Thanks for contributing to ImageSharp.Drawing! -->
![wrapped](https://github.com/user-attachments/assets/30ef7481-8e24-464e-94b8-f80bd7db5c7e)

