### PR TITLE
[2.x] Use macos-26-intel on CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
             sdk-preview: true
             runtime: -x64
             codecov: false
-          - os: macos-13 # macos-latest runs on arm64 runners where libgdiplus is unavailable
+          - os: macos-26-intel
             framework: net7.0
             sdk: 7.0.x
             sdk-preview: true
@@ -48,7 +48,7 @@ jobs:
             sdk: 6.0.x
             runtime: -x64
             codecov: false
-          - os: macos-13 # macos-latest runs on arm64 runners where libgdiplus is unavailable
+          - os: macos-26-intel
             framework: net6.0
             sdk: 6.0.x
             runtime: -x64


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
The `macos-13` (intel) runner has been retired, and the arm-based runners are crashing, almost certainly because of a 3rd party library used for testing. The good news is that are `*-intel` runners available which wins us some time [until their deprecation](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/#notice-of-macos-x86_64-intel-architecture-deprecation).