### PR TITLE
[1.x] Use macos-26-intel on CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
             framework: netcoreapp3.1
             runtime: -x64
             codecov: false
-          - os: macos-latest
+          - os: macos-26-intel
             framework: netcoreapp3.1
             runtime: -x64
             codecov: false


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
Same as #383 but for 1.0, which I have no idea if it still builds or not.