### PR TITLE
Add hatch pattern brushes and reference images

### DIFF
--- a/src/ImageSharp.Drawing/Processing/Brushes.Hatch.cs
+++ b/src/ImageSharp.Drawing/Processing/Brushes.Hatch.cs
@@ -1,0 +1,648 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+namespace SixLabors.ImageSharp.Drawing.Processing;
+
+/// <content>
+/// Provides additional hatch pattern brush factories.
+/// </content>
+public static partial class Brushes
+{
+    // These hatch arrays were derived using the GDI+ pixel extraction technique described at
+    // https://web.archive.org/web/20221228174326/https://www.codeproject.com/Articles/5350583/Recreating-Gdiplus-hatches-with-SkiaSharp.
+    private static readonly bool[,] HorizontalPattern =
+    {
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] VerticalPattern =
+    {
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] ForwardDiagonalPattern =
+    {
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  true,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  true,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] BackwardDiagonalPattern =
+    {
+        { false,  false,  false,  false,  false,  false,  false,  true, },
+        { false,  false,  false,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  false,  false,  true,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  false,  false, },
+        { false,  true,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] CrossPattern =
+    {
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] DiagonalCrossPattern =
+    {
+        { true,  false,  false,  false,  false,  false,  false,  true, },
+        { false,  true,  false,  false,  false,  false,  true,  false, },
+        { false,  false,  true,  false,  false,  true,  false,  false, },
+        { false,  false,  false,  true,  true,  false,  false,  false, },
+        { false,  false,  false,  true,  true,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  true,  false,  false, },
+        { false,  true,  false,  false,  false,  false,  true,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] Percent05Pattern =
+    {
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] Percent10Pattern =
+    {
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] Percent20Pattern =
+    {
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] Percent25Pattern =
+    {
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+    };
+
+    private static readonly bool[,] Percent30Pattern =
+    {
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  true,  false,  false,  false,  true,  false,  false, },
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  true, },
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  true,  false,  false,  false,  true,  false,  false, },
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] Percent40Pattern =
+    {
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  true,  false,  true,  false,  false,  false,  true, },
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  false,  false,  true,  false,  true,  false,  true, },
+    };
+
+    private static readonly bool[,] Percent50Pattern =
+    {
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+    };
+
+    private static readonly bool[,] Percent60Pattern =
+    {
+        { true,  true,  true,  false,  true,  true,  true,  false, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { true,  false,  true,  true,  true,  false,  true,  true, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { true,  true,  true,  false,  true,  true,  true,  false, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { true,  false,  true,  true,  true,  false,  true,  true, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+    };
+
+    private static readonly bool[,] Percent70Pattern =
+    {
+        { false,  true,  true,  true,  false,  true,  true,  true, },
+        { true,  true,  false,  true,  true,  true,  false,  true, },
+        { false,  true,  true,  true,  false,  true,  true,  true, },
+        { true,  true,  false,  true,  true,  true,  false,  true, },
+        { false,  true,  true,  true,  false,  true,  true,  true, },
+        { true,  true,  false,  true,  true,  true,  false,  true, },
+        { false,  true,  true,  true,  false,  true,  true,  true, },
+        { true,  true,  false,  true,  true,  true,  false,  true, },
+    };
+
+    private static readonly bool[,] Percent75Pattern =
+    {
+        { false,  true,  true,  true,  false,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  false,  true,  true,  true,  false,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  true,  true,  true,  false,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  false,  true,  true,  true,  false,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+    };
+
+    private static readonly bool[,] Percent80Pattern =
+    {
+        { true,  true,  true,  false,  true,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  true,  false,  true,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+    };
+
+    private static readonly bool[,] Percent90Pattern =
+    {
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  true,  true,  false,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  true,  true,  true,  true,  true,  true,  true, },
+    };
+
+    private static readonly bool[,] LightDownwardDiagonalPattern =
+    {
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  true,  false,  false,  false,  true,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  true, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  true,  false,  false,  false,  true,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] LightUpwardDiagonalPattern =
+    {
+        { false,  false,  false,  true,  false,  false,  false,  true, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  true,  false,  false,  false,  true,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  true, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  true,  false,  false,  false,  true,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] DarkDownwardDiagonalPattern =
+    {
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+        { false,  true,  true,  false,  false,  true,  true,  false, },
+        { false,  false,  true,  true,  false,  false,  true,  true, },
+        { true,  false,  false,  true,  true,  false,  false,  true, },
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+        { false,  true,  true,  false,  false,  true,  true,  false, },
+        { false,  false,  true,  true,  false,  false,  true,  true, },
+        { true,  false,  false,  true,  true,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] DarkUpwardDiagonalPattern =
+    {
+        { false,  false,  true,  true,  false,  false,  true,  true, },
+        { false,  true,  true,  false,  false,  true,  true,  false, },
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+        { true,  false,  false,  true,  true,  false,  false,  true, },
+        { false,  false,  true,  true,  false,  false,  true,  true, },
+        { false,  true,  true,  false,  false,  true,  true,  false, },
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+        { true,  false,  false,  true,  true,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] WideDownwardDiagonalPattern =
+    {
+        { true,  true,  false,  false,  false,  false,  false,  true, },
+        { true,  true,  true,  false,  false,  false,  false,  false, },
+        { false,  true,  true,  true,  false,  false,  false,  false, },
+        { false,  false,  true,  true,  true,  false,  false,  false, },
+        { false,  false,  false,  true,  true,  true,  false,  false, },
+        { false,  false,  false,  false,  true,  true,  true,  false, },
+        { false,  false,  false,  false,  false,  true,  true,  true, },
+        { true,  false,  false,  false,  false,  false,  true,  true, },
+    };
+
+    private static readonly bool[,] WideUpwardDiagonalPattern =
+    {
+        { true,  false,  false,  false,  false,  false,  true,  true, },
+        { false,  false,  false,  false,  false,  true,  true,  true, },
+        { false,  false,  false,  false,  true,  true,  true,  false, },
+        { false,  false,  false,  true,  true,  true,  false,  false, },
+        { false,  false,  true,  true,  true,  false,  false,  false, },
+        { false,  true,  true,  true,  false,  false,  false,  false, },
+        { true,  true,  true,  false,  false,  false,  false,  false, },
+        { true,  true,  false,  false,  false,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] LightVerticalPattern =
+    {
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] LightHorizontalPattern =
+    {
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] NarrowVerticalPattern =
+    {
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+    };
+
+    private static readonly bool[,] NarrowHorizontalPattern =
+    {
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] DarkVerticalPattern =
+    {
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+        { true,  true,  false,  false,  true,  true,  false,  false, },
+    };
+
+    private static readonly bool[,] DarkHorizontalPattern =
+    {
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] DashedDownwardDiagonalPattern =
+    {
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  true,  false,  false,  false,  true,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] DashedUpwardDiagonalPattern =
+    {
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  true, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  true,  false,  false,  false,  true,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] DashedHorizontalPattern =
+    {
+        { true,  true,  true,  true,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] DashedVerticalPattern =
+    {
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] SmallConfettiPattern =
+    {
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  true,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  true, },
+        { false,  false,  true,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  true,  false,  false, },
+    };
+
+    private static readonly bool[,] LargeConfettiPattern =
+    {
+        { true,  false,  true,  true,  false,  false,  false,  true, },
+        { false,  false,  true,  true,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  true,  true, },
+        { false,  false,  false,  true,  true,  false,  true,  true, },
+        { true,  true,  false,  true,  true,  false,  false,  false, },
+        { true,  true,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  true,  false,  false, },
+        { true,  false,  false,  false,  true,  true,  false,  true, },
+    };
+
+    private static readonly bool[,] ZigZagPattern =
+    {
+        { true,  false,  false,  false,  false,  false,  false,  true, },
+        { false,  true,  false,  false,  false,  false,  true,  false, },
+        { false,  false,  true,  false,  false,  true,  false,  false, },
+        { false,  false,  false,  true,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  true, },
+        { false,  true,  false,  false,  false,  false,  true,  false, },
+        { false,  false,  true,  false,  false,  true,  false,  false, },
+        { false,  false,  false,  true,  true,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] WavePattern =
+    {
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  true,  true,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  true,  false,  true, },
+        { true,  true,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  true,  true,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  true,  false,  true, },
+        { true,  true,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] DiagonalBrickPattern =
+    {
+        { false,  false,  false,  false,  false,  false,  false,  true, },
+        { false,  false,  false,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  false,  false,  true,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  true,  true,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  true,  false,  false, },
+        { false,  true,  false,  false,  false,  false,  true,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] HorizontalBrickPattern =
+    {
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] WeavePattern =
+    {
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  true,  false,  true,  false,  true,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  true,  false,  false,  false,  true,  false,  true, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  true,  false,  true,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  true,  false,  true,  false,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] PlaidPattern =
+    {
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  true,  false,  true,  false,  true,  false,  true, },
+        { true,  true,  true,  true,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] DivotPattern =
+    {
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  true, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] DottedGridPattern =
+    {
+        { true,  false,  true,  false,  true,  false,  true,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] DottedDiamondPattern =
+    {
+        { true,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+        { false,  false,  true,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] ShinglePattern =
+    {
+        { false,  false,  false,  false,  false,  false,  true,  true, },
+        { true,  false,  false,  false,  false,  true,  false,  false, },
+        { false,  true,  false,  false,  true,  false,  false,  false, },
+        { false,  false,  true,  true,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  true,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  true, },
+        { false,  false,  false,  false,  false,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] TrellisPattern =
+    {
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  true,  true,  false,  false,  true,  true,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  false,  false,  true,  true,  false,  false,  true, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { false,  true,  true,  false,  false,  true,  true,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  false,  false,  true,  true,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] SpherePattern =
+    {
+        { false,  true,  true,  true,  false,  true,  true,  true, },
+        { true,  false,  false,  false,  true,  false,  false,  true, },
+        { true,  false,  false,  false,  true,  true,  true,  true, },
+        { true,  false,  false,  false,  true,  true,  true,  true, },
+        { false,  true,  true,  true,  false,  true,  true,  true, },
+        { true,  false,  false,  true,  true,  false,  false,  false, },
+        { true,  true,  true,  true,  true,  false,  false,  false, },
+        { true,  true,  true,  true,  true,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] SmallGridPattern =
+    {
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  true, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+        { true,  false,  false,  false,  true,  false,  false,  false, },
+    };
+
+    private static readonly bool[,] SmallCheckerBoardPattern =
+    {
+        { true,  false,  false,  true,  true,  false,  false,  true, },
+        { false,  true,  true,  false,  false,  true,  true,  false, },
+        { false,  true,  true,  false,  false,  true,  true,  false, },
+        { true,  false,  false,  true,  true,  false,  false,  true, },
+        { true,  false,  false,  true,  true,  false,  false,  true, },
+        { false,  true,  true,  false,  false,  true,  true,  false, },
+        { false,  true,  true,  false,  false,  true,  true,  false, },
+        { true,  false,  false,  true,  true,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] LargeCheckerBoardPattern =
+    {
+        { true,  true,  true,  true,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  false,  false,  false,  false, },
+        { true,  true,  true,  true,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  true,  true,  true,  true, },
+        { false,  false,  false,  false,  true,  true,  true,  true, },
+    };
+
+    private static readonly bool[,] OutlinedDiamondPattern =
+    {
+        { true,  false,  false,  false,  false,  false,  true,  false, },
+        { false,  true,  false,  false,  false,  true,  false,  false, },
+        { false,  false,  true,  false,  true,  false,  false,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  false, },
+        { false,  false,  true,  false,  true,  false,  false,  false, },
+        { false,  true,  false,  false,  false,  true,  false,  false, },
+        { true,  false,  false,  false,  false,  false,  true,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  true, },
+    };
+
+    private static readonly bool[,] SolidDiamondPattern =
+    {
+        { false,  false,  false,  true,  false,  false,  false,  false, },
+        { false,  false,  true,  true,  true,  false,  false,  false, },
+        { false,  true,  true,  true,  true,  true,  false,  false, },
+        { true,  true,  true,  true,  true,  true,  true,  false, },
+        { false,  true,  true,  true,  true,  true,  false,  false, },
+        { false,  false,  true,  true,  true,  false,  false,  false, },
+        { false,  false,  false,  true,  false,  false,  false,  false, },
+        { false,  false,  false,  false,  false,  false,  false,  false, },
+    };
+}

--- a/src/ImageSharp.Drawing/Processing/Brushes.cs
+++ b/src/ImageSharp.Drawing/Processing/Brushes.cs
@@ -6,217 +6,836 @@ namespace SixLabors.ImageSharp.Drawing.Processing;
 /// <summary>
 /// A collection of methods for creating generic brushes.
 /// </summary>
-/// <returns>A new <see cref="PatternBrush"/></returns>
-public static class Brushes
+public static partial class Brushes
 {
     /// <summary>
-    /// Percent10 Hatch Pattern
+    /// Creates a brush that paints a solid color.
     /// </summary>
-    /// ---> x axis
-    /// ^
-    /// | y - axis
-    /// |
-    /// see PatternBrush for details about how to make new patterns work
-    private static readonly bool[,] Percent10Pattern =
-    {
-        { true, false, false, false },
-        { false, false, false, false },
-        { false, false, true, false },
-        { false, false, false, false }
-    };
-
-    /// <summary>
-    /// Percent20 pattern.
-    /// </summary>
-    private static readonly bool[,] Percent20Pattern =
-    {
-        { true,  false, false, false },
-        { false, false, true,  false },
-        { true,  false, false, false },
-        { false, false, true,  false }
-    };
-
-    /// <summary>
-    /// Horizontal Hatch Pattern
-    /// </summary>
-    private static readonly bool[,] HorizontalPattern =
-    {
-        { false },
-        { true },
-        { false },
-        { false }
-    };
-
-    /// <summary>
-    /// Min Pattern
-    /// </summary>
-    private static readonly bool[,] MinPattern =
-    {
-        { false },
-        { false },
-        { false },
-        { true }
-    };
-
-    /// <summary>
-    /// Vertical Pattern
-    /// </summary>
-    private static readonly bool[,] VerticalPattern =
-    {
-        { false, true, false, false },
-    };
-
-    /// <summary>
-    /// Forward Diagonal Pattern
-    /// </summary>
-    private static readonly bool[,] ForwardDiagonalPattern =
-    {
-        { false, false, false, true },
-        { false, false, true, false },
-        { false, true, false, false },
-        { true,  false, false, false }
-    };
-
-    /// <summary>
-    /// Backward Diagonal Pattern
-    /// </summary>
-    private static readonly bool[,] BackwardDiagonalPattern =
-    {
-        { true, false, false, false },
-        { false, true, false, false },
-        { false, false, true, false },
-        { false, false, false, true }
-    };
-
-    /// <summary>
-    /// Create as brush that will paint a solid color
-    /// </summary>
-    /// <param name="color">The color.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
+    /// <param name="color">The brush color.</param>
+    /// <returns>A new <see cref="SolidBrush"/>.</returns>
     public static SolidBrush Solid(Color color) => new(color);
 
     /// <summary>
-    /// Create as brush that will paint a Percent10 Hatch Pattern with the specified colors
+    /// Creates a brush that paints horizontal line hatching using the foreground color on a transparent background.
     /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
-    public static PatternBrush Percent10(Color foreColor)
-        => new(foreColor, Color.Transparent, Percent10Pattern);
-
-    /// <summary>
-    /// Create as brush that will paint a Percent10 Hatch Pattern with the specified colors
-    /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <param name="backColor">Color of the background.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
-    public static PatternBrush Percent10(Color foreColor, Color backColor)
-        => new(foreColor, backColor, Percent10Pattern);
-
-    /// <summary>
-    /// Create as brush that will paint a Percent20 Hatch Pattern with the specified foreground color and a
-    /// transparent background.
-    /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
-    public static PatternBrush Percent20(Color foreColor)
-        => new(foreColor, Color.Transparent, Percent20Pattern);
-
-    /// <summary>
-    /// Create as brush that will paint a Percent20 Hatch Pattern with the specified colors
-    /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <param name="backColor">Color of the background.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
-    public static PatternBrush Percent20(Color foreColor, Color backColor)
-        => new(foreColor, backColor, Percent20Pattern);
-
-    /// <summary>
-    /// Create as brush that will paint a Horizontal Hatch Pattern with the specified foreground color and a
-    /// transparent background.
-    /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
     public static PatternBrush Horizontal(Color foreColor)
         => new(foreColor, Color.Transparent, HorizontalPattern);
 
     /// <summary>
-    /// Create as brush that will paint a Horizontal Hatch Pattern with the specified colors
+    /// Creates a brush that paints horizontal line hatching using the specified foreground and background colors.
     /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <param name="backColor">Color of the background.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
     public static PatternBrush Horizontal(Color foreColor, Color backColor)
         => new(foreColor, backColor, HorizontalPattern);
 
     /// <summary>
-    /// Create as brush that will paint a Min Hatch Pattern with the specified foreground color and a
-    /// transparent background.
+    /// Creates a brush that paints horizontal line hatching for the minimum hatch style using the foreground color on a transparent background.
     /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
     public static PatternBrush Min(Color foreColor)
-        => new(foreColor, Color.Transparent, MinPattern);
+        => new(foreColor, Color.Transparent, HorizontalPattern);
 
     /// <summary>
-    /// Create as brush that will paint a Min Hatch Pattern with the specified colors
+    /// Creates a brush that paints horizontal line hatching for the minimum hatch style using the specified foreground and background colors.
     /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <param name="backColor">Color of the background.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
     public static PatternBrush Min(Color foreColor, Color backColor)
-        => new(foreColor, backColor, MinPattern);
+        => new(foreColor, backColor, HorizontalPattern);
 
     /// <summary>
-    /// Create as brush that will paint a Vertical Hatch Pattern with the specified foreground color and a
-    /// transparent background.
+    /// Creates a brush that paints vertical line hatching using the foreground color on a transparent background.
     /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
     public static PatternBrush Vertical(Color foreColor)
         => new(foreColor, Color.Transparent, VerticalPattern);
 
     /// <summary>
-    /// Create as brush that will paint a Vertical Hatch Pattern with the specified colors
+    /// Creates a brush that paints vertical line hatching using the specified foreground and background colors.
     /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <param name="backColor">Color of the background.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
     public static PatternBrush Vertical(Color foreColor, Color backColor)
         => new(foreColor, backColor, VerticalPattern);
 
     /// <summary>
-    /// Create as brush that will paint a Forward Diagonal Hatch Pattern with the specified foreground color and a
-    /// transparent background.
+    /// Creates a brush that paints diagonal line hatching from upper left to lower right using the foreground color on a transparent background.
     /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
     public static PatternBrush ForwardDiagonal(Color foreColor)
         => new(foreColor, Color.Transparent, ForwardDiagonalPattern);
 
     /// <summary>
-    /// Create as brush that will paint a Forward Diagonal Hatch Pattern with the specified colors
+    /// Creates a brush that paints diagonal line hatching from upper left to lower right using the specified foreground and background colors.
     /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <param name="backColor">Color of the background.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
     public static PatternBrush ForwardDiagonal(Color foreColor, Color backColor)
         => new(foreColor, backColor, ForwardDiagonalPattern);
 
     /// <summary>
-    /// Create as brush that will paint a Backward Diagonal Hatch Pattern with the specified foreground color and a
-    /// transparent background.
+    /// Creates a brush that paints diagonal line hatching from upper right to lower left using the foreground color on a transparent background.
     /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
     public static PatternBrush BackwardDiagonal(Color foreColor)
         => new(foreColor, Color.Transparent, BackwardDiagonalPattern);
 
     /// <summary>
-    /// Create as brush that will paint a Backward Diagonal Hatch Pattern with the specified colors
+    /// Creates a brush that paints diagonal line hatching from upper right to lower left using the specified foreground and background colors.
     /// </summary>
-    /// <param name="foreColor">Color of the foreground.</param>
-    /// <param name="backColor">Color of the background.</param>
-    /// <returns>A new <see cref="PatternBrush"/></returns>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
     public static PatternBrush BackwardDiagonal(Color foreColor, Color backColor)
         => new(foreColor, backColor, BackwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints intersecting horizontal and vertical line hatching using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Cross(Color foreColor) => new(foreColor, Color.Transparent, CrossPattern);
+
+    /// <summary>
+    /// Creates a brush that paints intersecting horizontal and vertical line hatching using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Cross(Color foreColor, Color backColor) => new(foreColor, backColor, CrossPattern);
+
+    /// <summary>
+    /// Creates a brush that paints intersecting forward and backward diagonal line hatching using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DiagonalCross(Color foreColor) => new(foreColor, Color.Transparent, DiagonalCrossPattern);
+
+    /// <summary>
+    /// Creates a brush that paints intersecting forward and backward diagonal line hatching using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DiagonalCross(Color foreColor, Color backColor) => new(foreColor, backColor, DiagonalCrossPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 5-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 5:95.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent05(Color foreColor) => new(foreColor, Color.Transparent, Percent05Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 5-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 5:95.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent05(Color foreColor, Color backColor) => new(foreColor, backColor, Percent05Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 10-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 10:90.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent10(Color foreColor)
+        => new(foreColor, Color.Transparent, Percent10Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 10-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 10:90.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent10(Color foreColor, Color backColor)
+        => new(foreColor, backColor, Percent10Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 20-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 20:80.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent20(Color foreColor)
+        => new(foreColor, Color.Transparent, Percent20Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 20-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 20:80.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent20(Color foreColor, Color backColor)
+        => new(foreColor, backColor, Percent20Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 25-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 25:75.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent25(Color foreColor) => new(foreColor, Color.Transparent, Percent25Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 25-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 25:75.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent25(Color foreColor, Color backColor) => new(foreColor, backColor, Percent25Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 30-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 30:70.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent30(Color foreColor) => new(foreColor, Color.Transparent, Percent30Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 30-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 30:70.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent30(Color foreColor, Color backColor) => new(foreColor, backColor, Percent30Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 40-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 40:60.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent40(Color foreColor) => new(foreColor, Color.Transparent, Percent40Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 40-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 40:60.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent40(Color foreColor, Color backColor) => new(foreColor, backColor, Percent40Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 50-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 50:50.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent50(Color foreColor) => new(foreColor, Color.Transparent, Percent50Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 50-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 50:50.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent50(Color foreColor, Color backColor) => new(foreColor, backColor, Percent50Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 60-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 60:40.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent60(Color foreColor) => new(foreColor, Color.Transparent, Percent60Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 60-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 60:40.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent60(Color foreColor, Color backColor) => new(foreColor, backColor, Percent60Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 70-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 70:30.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent70(Color foreColor) => new(foreColor, Color.Transparent, Percent70Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 70-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 70:30.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent70(Color foreColor, Color backColor) => new(foreColor, backColor, Percent70Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 75-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 75:25.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent75(Color foreColor) => new(foreColor, Color.Transparent, Percent75Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 75-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 75:25.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent75(Color foreColor, Color backColor) => new(foreColor, backColor, Percent75Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints an 80-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 80:20.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent80(Color foreColor) => new(foreColor, Color.Transparent, Percent80Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints an 80-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 80:20.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent80(Color foreColor, Color backColor) => new(foreColor, backColor, Percent80Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 90-percent hatch using the foreground color on a transparent background; the foreground-to-background color ratio is 90:10.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent90(Color foreColor) => new(foreColor, Color.Transparent, Percent90Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints a 90-percent hatch using the specified foreground and background colors; the foreground-to-background color ratio is 90:10.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Percent90(Color foreColor, Color backColor) => new(foreColor, backColor, Percent90Pattern);
+
+    /// <summary>
+    /// Creates a brush that paints downward diagonal lines spaced more closely than ForwardDiagonal using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LightDownwardDiagonal(Color foreColor) => new(foreColor, Color.Transparent, LightDownwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints downward diagonal lines spaced more closely than ForwardDiagonal using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LightDownwardDiagonal(Color foreColor, Color backColor) => new(foreColor, backColor, LightDownwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints upward diagonal lines spaced more closely than BackwardDiagonal using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LightUpwardDiagonal(Color foreColor) => new(foreColor, Color.Transparent, LightUpwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints upward diagonal lines spaced more closely than BackwardDiagonal using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LightUpwardDiagonal(Color foreColor, Color backColor) => new(foreColor, backColor, LightUpwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints thicker downward diagonal lines spaced more closely than ForwardDiagonal using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DarkDownwardDiagonal(Color foreColor) => new(foreColor, Color.Transparent, DarkDownwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints thicker downward diagonal lines spaced more closely than ForwardDiagonal using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DarkDownwardDiagonal(Color foreColor, Color backColor) => new(foreColor, backColor, DarkDownwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints thicker upward diagonal lines spaced more closely than BackwardDiagonal using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DarkUpwardDiagonal(Color foreColor) => new(foreColor, Color.Transparent, DarkUpwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints thicker upward diagonal lines spaced more closely than BackwardDiagonal using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DarkUpwardDiagonal(Color foreColor, Color backColor) => new(foreColor, backColor, DarkUpwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints wide downward diagonal lines with ForwardDiagonal spacing using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush WideDownwardDiagonal(Color foreColor) => new(foreColor, Color.Transparent, WideDownwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints wide downward diagonal lines with ForwardDiagonal spacing using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush WideDownwardDiagonal(Color foreColor, Color backColor) => new(foreColor, backColor, WideDownwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints wide upward diagonal lines with BackwardDiagonal spacing using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush WideUpwardDiagonal(Color foreColor) => new(foreColor, Color.Transparent, WideUpwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints wide upward diagonal lines with BackwardDiagonal spacing using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush WideUpwardDiagonal(Color foreColor, Color backColor) => new(foreColor, backColor, WideUpwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints vertical lines spaced more closely than Vertical using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LightVertical(Color foreColor) => new(foreColor, Color.Transparent, LightVerticalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints vertical lines spaced more closely than Vertical using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LightVertical(Color foreColor, Color backColor) => new(foreColor, backColor, LightVerticalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints horizontal lines spaced more closely than Horizontal using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LightHorizontal(Color foreColor) => new(foreColor, Color.Transparent, LightHorizontalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints horizontal lines spaced more closely than Horizontal using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LightHorizontal(Color foreColor, Color backColor) => new(foreColor, backColor, LightHorizontalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints narrow vertical lines spaced more closely than LightVertical using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush NarrowVertical(Color foreColor) => new(foreColor, Color.Transparent, NarrowVerticalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints narrow vertical lines spaced more closely than LightVertical using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush NarrowVertical(Color foreColor, Color backColor) => new(foreColor, backColor, NarrowVerticalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints narrow horizontal lines spaced more closely than LightHorizontal using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush NarrowHorizontal(Color foreColor) => new(foreColor, Color.Transparent, NarrowHorizontalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints narrow horizontal lines spaced more closely than LightHorizontal using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush NarrowHorizontal(Color foreColor, Color backColor) => new(foreColor, backColor, NarrowHorizontalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints thicker vertical lines spaced more closely than Vertical using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DarkVertical(Color foreColor) => new(foreColor, Color.Transparent, DarkVerticalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints thicker vertical lines spaced more closely than Vertical using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DarkVertical(Color foreColor, Color backColor) => new(foreColor, backColor, DarkVerticalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints thicker horizontal lines spaced more closely than Horizontal using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DarkHorizontal(Color foreColor) => new(foreColor, Color.Transparent, DarkHorizontalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints thicker horizontal lines spaced more closely than Horizontal using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DarkHorizontal(Color foreColor, Color backColor) => new(foreColor, backColor, DarkHorizontalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints dashed diagonal lines from upper left to lower right using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DashedDownwardDiagonal(Color foreColor) => new(foreColor, Color.Transparent, DashedDownwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints dashed diagonal lines from upper left to lower right using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DashedDownwardDiagonal(Color foreColor, Color backColor) => new(foreColor, backColor, DashedDownwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints dashed diagonal lines from upper right to lower left using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DashedUpwardDiagonal(Color foreColor) => new(foreColor, Color.Transparent, DashedUpwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints dashed diagonal lines from upper right to lower left using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DashedUpwardDiagonal(Color foreColor, Color backColor) => new(foreColor, backColor, DashedUpwardDiagonalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints dashed horizontal lines using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DashedHorizontal(Color foreColor) => new(foreColor, Color.Transparent, DashedHorizontalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints dashed horizontal lines using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DashedHorizontal(Color foreColor, Color backColor) => new(foreColor, backColor, DashedHorizontalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints dashed vertical lines using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DashedVertical(Color foreColor) => new(foreColor, Color.Transparent, DashedVerticalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints dashed vertical lines using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DashedVertical(Color foreColor, Color backColor) => new(foreColor, backColor, DashedVerticalPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a small confetti-style hatch using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush SmallConfetti(Color foreColor) => new(foreColor, Color.Transparent, SmallConfettiPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a small confetti-style hatch using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush SmallConfetti(Color foreColor, Color backColor) => new(foreColor, backColor, SmallConfettiPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a confetti-style hatch with larger pieces than SmallConfetti using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LargeConfetti(Color foreColor) => new(foreColor, Color.Transparent, LargeConfettiPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a confetti-style hatch with larger pieces than SmallConfetti using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LargeConfetti(Color foreColor, Color backColor) => new(foreColor, backColor, LargeConfettiPattern);
+
+    /// <summary>
+    /// Creates a brush that paints horizontal lines formed from zigzags using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush ZigZag(Color foreColor) => new(foreColor, Color.Transparent, ZigZagPattern);
+
+    /// <summary>
+    /// Creates a brush that paints horizontal lines formed from zigzags using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush ZigZag(Color foreColor, Color backColor) => new(foreColor, backColor, ZigZagPattern);
+
+    /// <summary>
+    /// Creates a brush that paints horizontal lines formed from wave shapes using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Wave(Color foreColor) => new(foreColor, Color.Transparent, WavePattern);
+
+    /// <summary>
+    /// Creates a brush that paints horizontal lines formed from wave shapes using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Wave(Color foreColor, Color backColor) => new(foreColor, backColor, WavePattern);
+
+    /// <summary>
+    /// Creates a brush that paints staggered brick shapes running diagonally upward using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DiagonalBrick(Color foreColor) => new(foreColor, Color.Transparent, DiagonalBrickPattern);
+
+    /// <summary>
+    /// Creates a brush that paints staggered brick shapes running diagonally upward using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DiagonalBrick(Color foreColor, Color backColor) => new(foreColor, backColor, DiagonalBrickPattern);
+
+    /// <summary>
+    /// Creates a brush that paints staggered brick shapes arranged horizontally using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush HorizontalBrick(Color foreColor) => new(foreColor, Color.Transparent, HorizontalBrickPattern);
+
+    /// <summary>
+    /// Creates a brush that paints staggered brick shapes arranged horizontally using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush HorizontalBrick(Color foreColor, Color backColor) => new(foreColor, backColor, HorizontalBrickPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a woven-material hatch using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Weave(Color foreColor) => new(foreColor, Color.Transparent, WeavePattern);
+
+    /// <summary>
+    /// Creates a brush that paints a woven-material hatch using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Weave(Color foreColor, Color backColor) => new(foreColor, backColor, WeavePattern);
+
+    /// <summary>
+    /// Creates a brush that paints a plaid-material hatch using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Plaid(Color foreColor) => new(foreColor, Color.Transparent, PlaidPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a plaid-material hatch using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Plaid(Color foreColor, Color backColor) => new(foreColor, backColor, PlaidPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a divot-style hatch using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Divot(Color foreColor) => new(foreColor, Color.Transparent, DivotPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a divot-style hatch using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Divot(Color foreColor, Color backColor) => new(foreColor, backColor, DivotPattern);
+
+    /// <summary>
+    /// Creates a brush that paints intersecting horizontal and vertical dotted lines using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DottedGrid(Color foreColor) => new(foreColor, Color.Transparent, DottedGridPattern);
+
+    /// <summary>
+    /// Creates a brush that paints intersecting horizontal and vertical dotted lines using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DottedGrid(Color foreColor, Color backColor) => new(foreColor, backColor, DottedGridPattern);
+
+    /// <summary>
+    /// Creates a brush that paints intersecting forward and backward diagonal dotted lines using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DottedDiamond(Color foreColor) => new(foreColor, Color.Transparent, DottedDiamondPattern);
+
+    /// <summary>
+    /// Creates a brush that paints intersecting forward and backward diagonal dotted lines using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush DottedDiamond(Color foreColor, Color backColor) => new(foreColor, backColor, DottedDiamondPattern);
+
+    /// <summary>
+    /// Creates a brush that paints layered shingle shapes running diagonally downward using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Shingle(Color foreColor) => new(foreColor, Color.Transparent, ShinglePattern);
+
+    /// <summary>
+    /// Creates a brush that paints layered shingle shapes running diagonally downward using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Shingle(Color foreColor, Color backColor) => new(foreColor, backColor, ShinglePattern);
+
+    /// <summary>
+    /// Creates a brush that paints a trellis-style hatch using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Trellis(Color foreColor) => new(foreColor, Color.Transparent, TrellisPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a trellis-style hatch using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Trellis(Color foreColor, Color backColor) => new(foreColor, backColor, TrellisPattern);
+
+    /// <summary>
+    /// Creates a brush that paints adjacent sphere-like shapes using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Sphere(Color foreColor) => new(foreColor, Color.Transparent, SpherePattern);
+
+    /// <summary>
+    /// Creates a brush that paints adjacent sphere-like shapes using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush Sphere(Color foreColor, Color backColor) => new(foreColor, backColor, SpherePattern);
+
+    /// <summary>
+    /// Creates a brush that paints intersecting horizontal and vertical lines spaced more closely than Cross using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush SmallGrid(Color foreColor) => new(foreColor, Color.Transparent, SmallGridPattern);
+
+    /// <summary>
+    /// Creates a brush that paints intersecting horizontal and vertical lines spaced more closely than Cross using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush SmallGrid(Color foreColor, Color backColor) => new(foreColor, backColor, SmallGridPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a small checkerboard hatch using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush SmallCheckerBoard(Color foreColor) => new(foreColor, Color.Transparent, SmallCheckerBoardPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a small checkerboard hatch using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush SmallCheckerBoard(Color foreColor, Color backColor) => new(foreColor, backColor, SmallCheckerBoardPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a checkerboard hatch with larger squares than SmallCheckerBoard using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LargeCheckerBoard(Color foreColor) => new(foreColor, Color.Transparent, LargeCheckerBoardPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a checkerboard hatch with larger squares than SmallCheckerBoard using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush LargeCheckerBoard(Color foreColor, Color backColor) => new(foreColor, backColor, LargeCheckerBoardPattern);
+
+    /// <summary>
+    /// Creates a brush that paints outlined diamond shapes formed by crossing diagonal lines using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush OutlinedDiamond(Color foreColor) => new(foreColor, Color.Transparent, OutlinedDiamondPattern);
+
+    /// <summary>
+    /// Creates a brush that paints outlined diamond shapes formed by crossing diagonal lines using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush OutlinedDiamond(Color foreColor, Color backColor) => new(foreColor, backColor, OutlinedDiamondPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a filled diamond checkerboard hatch using the foreground color on a transparent background.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush SolidDiamond(Color foreColor) => new(foreColor, Color.Transparent, SolidDiamondPattern);
+
+    /// <summary>
+    /// Creates a brush that paints a filled diamond checkerboard hatch using the specified foreground and background colors.
+    /// </summary>
+    /// <param name="foreColor">The foreground color.</param>
+    /// <param name="backColor">The background color.</param>
+    /// <returns>A new <see cref="PatternBrush"/>.</returns>
+    public static PatternBrush SolidDiamond(Color foreColor, Color backColor) => new(foreColor, backColor, SolidDiamondPattern);
 }

--- a/tests/ImageSharp.Drawing.Tests/Processing/ProcessWithDrawingCanvasTests.PatternBrushes.cs
+++ b/tests/ImageSharp.Drawing.Tests/Processing/ProcessWithDrawingCanvasTests.PatternBrushes.cs
@@ -11,6 +11,92 @@ namespace SixLabors.ImageSharp.Drawing.Tests.Processing;
 
 public partial class ProcessWithDrawingCanvasTests
 {
+    private const int HatchGalleryColumns = 9;
+
+    private const int HatchGalleryTileSize = 64;
+
+    private static readonly Func<Color, Color, PatternBrush>[] HatchGalleryBrushes =
+    [
+        Brushes.Horizontal,
+        Brushes.Vertical,
+        Brushes.ForwardDiagonal,
+        Brushes.BackwardDiagonal,
+        Brushes.Cross,
+        Brushes.DiagonalCross,
+        Brushes.Percent05,
+        Brushes.Percent10,
+        Brushes.Percent20,
+        Brushes.Percent25,
+        Brushes.Percent30,
+        Brushes.Percent40,
+        Brushes.Percent50,
+        Brushes.Percent60,
+        Brushes.Percent70,
+        Brushes.Percent75,
+        Brushes.Percent80,
+        Brushes.Percent90,
+        Brushes.LightDownwardDiagonal,
+        Brushes.LightUpwardDiagonal,
+        Brushes.DarkDownwardDiagonal,
+        Brushes.DarkUpwardDiagonal,
+        Brushes.WideDownwardDiagonal,
+        Brushes.WideUpwardDiagonal,
+        Brushes.LightVertical,
+        Brushes.LightHorizontal,
+        Brushes.NarrowVertical,
+        Brushes.NarrowHorizontal,
+        Brushes.DarkVertical,
+        Brushes.DarkHorizontal,
+        Brushes.DashedDownwardDiagonal,
+        Brushes.DashedUpwardDiagonal,
+        Brushes.DashedHorizontal,
+        Brushes.DashedVertical,
+        Brushes.SmallConfetti,
+        Brushes.LargeConfetti,
+        Brushes.ZigZag,
+        Brushes.Wave,
+        Brushes.DiagonalBrick,
+        Brushes.HorizontalBrick,
+        Brushes.Weave,
+        Brushes.Plaid,
+        Brushes.Divot,
+        Brushes.DottedGrid,
+        Brushes.DottedDiamond,
+        Brushes.Shingle,
+        Brushes.Trellis,
+        Brushes.Sphere,
+        Brushes.SmallGrid,
+        Brushes.SmallCheckerBoard,
+        Brushes.LargeCheckerBoard,
+        Brushes.OutlinedDiamond,
+        Brushes.SolidDiamond,
+        Brushes.Min
+    ];
+
+    [Theory]
+    [WithBlankImage(HatchGalleryColumns * HatchGalleryTileSize, 6 * HatchGalleryTileSize, PixelTypes.Rgba32)]
+    public void HatchPatternBrushes_RenderGallery<TPixel>(TestImageProvider<TPixel> provider)
+        where TPixel : unmanaged, IPixel<TPixel>
+        => provider.RunValidatingProcessorTest(
+            image => image.Paint(canvas =>
+            {
+                canvas.Fill(Brushes.Solid(Color.White));
+
+                for (int i = 0; i < HatchGalleryBrushes.Length; i++)
+                {
+                    int x = (i % HatchGalleryColumns) * HatchGalleryTileSize;
+                    int y = (i / HatchGalleryColumns) * HatchGalleryTileSize;
+                    Rectangle tile = new(x + 4, y + 4, HatchGalleryTileSize - 8, HatchGalleryTileSize - 8);
+                    Color foreground = Color.FromPixel(new Rgba32((byte)(36 + ((i * 37) % 160)), 48, (byte)(96 + ((i * 19) % 120)), 220));
+                    Color background = Color.FromPixel(new Rgba32((byte)(232 - ((i * 11) % 72)), (byte)(238 - ((i * 7) % 64)), 224, 255));
+
+                    canvas.Fill(HatchGalleryBrushes[i](foreground, background), tile);
+                    canvas.Draw(Pens.Solid(Color.DarkSlateGray, 1F), tile);
+                }
+            }),
+            appendPixelTypeToFileName: false,
+            appendSourceFileOrDescription: false);
+
     [Theory]
     [WithBlankImage(20, 20, PixelTypes.Rgba32)]
     public void FillPatternBrushImageShouldBeFloodFilledWithPercent10<TPixel>(TestImageProvider<TPixel> provider)
@@ -18,10 +104,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen },
-            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen }
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen }
         };
 
         VerifyFloodFillPattern(provider, Brushes.Percent10(Color.HotPink, Color.LimeGreen), expectedPattern);
@@ -34,10 +124,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue },
-            { Color.Blue, Color.Blue, Color.Blue, Color.Blue },
-            { Color.Blue, Color.Blue, Color.HotPink, Color.Blue },
-            { Color.Blue, Color.Blue, Color.Blue, Color.Blue }
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue }
         };
 
         VerifyFloodFillPattern(provider, Brushes.Percent10(Color.HotPink), expectedPattern);
@@ -50,10 +144,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen },
-            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen }
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen }
         };
 
         VerifyFloodFillPattern(provider, Brushes.Percent20(Color.HotPink, Color.LimeGreen), expectedPattern);
@@ -66,10 +164,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue },
-            { Color.Blue, Color.Blue, Color.HotPink, Color.Blue },
-            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue },
-            { Color.Blue, Color.Blue, Color.HotPink, Color.Blue }
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue }
         };
 
         VerifyFloodFillPattern(provider, Brushes.Percent20(Color.HotPink), expectedPattern);
@@ -82,10 +184,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
-            { Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink },
-            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen }
+            { Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen }
         };
 
         VerifyFloodFillPattern(provider, Brushes.Horizontal(Color.HotPink, Color.LimeGreen), expectedPattern);
@@ -98,10 +204,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.Blue, Color.Blue, Color.Blue, Color.Blue },
-            { Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink },
-            { Color.Blue, Color.Blue, Color.Blue, Color.Blue },
-            { Color.Blue, Color.Blue, Color.Blue, Color.Blue }
+            { Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue }
         };
 
         VerifyFloodFillPattern(provider, Brushes.Horizontal(Color.HotPink), expectedPattern);
@@ -114,10 +224,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
-            { Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink }
+            { Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen }
         };
 
         VerifyFloodFillPattern(provider, Brushes.Min(Color.HotPink, Color.LimeGreen), expectedPattern);
@@ -130,10 +244,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.Blue, Color.Blue, Color.Blue, Color.Blue },
-            { Color.Blue, Color.Blue, Color.Blue, Color.Blue },
-            { Color.Blue, Color.Blue, Color.Blue, Color.Blue },
-            { Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink }
+            { Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink, Color.HotPink },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue }
         };
 
         VerifyFloodFillPattern(provider, Brushes.Min(Color.HotPink), expectedPattern);
@@ -146,10 +264,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen }
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen }
         };
 
         VerifyFloodFillPattern(provider, Brushes.Vertical(Color.HotPink, Color.LimeGreen), expectedPattern);
@@ -162,10 +284,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.Blue, Color.HotPink, Color.Blue, Color.Blue },
-            { Color.Blue, Color.HotPink, Color.Blue, Color.Blue },
-            { Color.Blue, Color.HotPink, Color.Blue, Color.Blue },
-            { Color.Blue, Color.HotPink, Color.Blue, Color.Blue }
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue }
         };
 
         VerifyFloodFillPattern(provider, Brushes.Vertical(Color.HotPink), expectedPattern);
@@ -178,10 +304,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink },
-            { Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen },
-            { Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen },
-            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen }
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink }
         };
 
         VerifyFloodFillPattern(provider, Brushes.ForwardDiagonal(Color.HotPink, Color.LimeGreen), expectedPattern);
@@ -194,10 +324,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.Blue, Color.Blue, Color.Blue, Color.HotPink },
-            { Color.Blue, Color.Blue, Color.HotPink, Color.Blue },
-            { Color.Blue, Color.HotPink, Color.Blue, Color.Blue },
-            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue }
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.HotPink }
         };
 
         VerifyFloodFillPattern(provider, Brushes.ForwardDiagonal(Color.HotPink), expectedPattern);
@@ -210,10 +344,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen },
-            { Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen },
-            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink }
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.LimeGreen, Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen },
+            { Color.HotPink, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen, Color.LimeGreen }
         };
 
         VerifyFloodFillPattern(provider, Brushes.BackwardDiagonal(Color.HotPink, Color.LimeGreen), expectedPattern);
@@ -226,10 +364,14 @@ public partial class ProcessWithDrawingCanvasTests
     {
         Color[,] expectedPattern = new Color[,]
         {
-            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue },
-            { Color.Blue, Color.HotPink, Color.Blue, Color.Blue },
-            { Color.Blue, Color.Blue, Color.HotPink, Color.Blue },
-            { Color.Blue, Color.Blue, Color.Blue, Color.HotPink }
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.HotPink },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.Blue, Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue },
+            { Color.HotPink, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue, Color.Blue }
         };
 
         VerifyFloodFillPattern(provider, Brushes.BackwardDiagonal(Color.HotPink), expectedPattern);

--- a/tests/Images/ReferenceOutput/Drawing/DrawingCanvasTests/Draw_WithPatternAndGradientPens_MatchesReference_Rgba32.png
+++ b/tests/Images/ReferenceOutput/Drawing/DrawingCanvasTests/Draw_WithPatternAndGradientPens_MatchesReference_Rgba32.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4deb9d8573b742d3425eb065a9fada663b5a47a7b4c298f2b3db6d22e846033d
-size 11156
+oid sha256:5064b994cba9dee461bb310a2d0e1544d61b547605d6061980697d4ab8ea477f
+size 9781

--- a/tests/Images/ReferenceOutput/Drawing/DrawingCanvasTests/Fill_WithGradientAndPatternBrushes_MatchesReference_Rgba32.png
+++ b/tests/Images/ReferenceOutput/Drawing/DrawingCanvasTests/Fill_WithGradientAndPatternBrushes_MatchesReference_Rgba32.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:579ccbf5b75518be0813d8be3fd86eb3003a76122abee818f07ac59649777023
-size 18941
+oid sha256:61d473ea6d0e639a3d87888f85157e39c1b4d87c499705021eea9c5c4ef8dd9a
+size 18913

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithBackwardDiagonal.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithBackwardDiagonal.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25f45451fe5c6898611cdd7504d5f68a419e3fe8e2614cc5da1b0022b6a8864e
-size 103
+oid sha256:cb6a0c97ed2ffb2d7b4423c955bcddd6e7e4d2fe63f858f9905608d66c2dcc9f
+size 118

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithBackwardDiagonalTransparent.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithBackwardDiagonalTransparent.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01608bed44a5e936807fb77b44ba1d2f4bccd84efd0774d29145775521a90892
-size 103
+oid sha256:52f923d3318bdafc31e2639dc1b40be07c1393a19b80299ab4a66517cca60deb
+size 118

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithForwardDiagonal.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithForwardDiagonal.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0693514c8034ecc07a6eba1971b7a35343226d757fd66603c9e4d09864747b8a
-size 102
+oid sha256:f81027e6454cf5f706eac6f8e4abfe553d7767fc4948497650bf3aa2a0ffd740
+size 121

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithForwardDiagonalTransparent.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithForwardDiagonalTransparent.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23882cab09040361405de161753c0ffe2f27f6d3160495edf3ebff25cc4ca4b8
-size 102
+oid sha256:2e6b9933538bb01246b52078d15a7dabb76e67c0f3bd30bfc5068f0a244bb9b6
+size 121

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithHorizontal.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithHorizontal.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87eeebbfd7a24863bf73aa42b544528f7928ff7dc80d698f7650aafa28487d85
+oid sha256:4e2d6e130e2c878ec1052bc9f48e1a18a63eeb6add03f4a8829b3a37dc003112
 size 93

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithHorizontalTransparent.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithHorizontalTransparent.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87b01b762fa99c54d5a294640344e559768b049e9d1954e2ccd5205f9fb82126
+oid sha256:3955d2809fbd378dee6aa0f1f4afbb16f1075ba3c3f3cc30b235ccb11ca80ff6
 size 93

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithMin.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithMin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b813035f11b0d3abc80360ad38ced07ec0961d0744e438c13650bf76185dfdb1
-size 91
+oid sha256:4e2d6e130e2c878ec1052bc9f48e1a18a63eeb6add03f4a8829b3a37dc003112
+size 93

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithMinTransparent.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithMinTransparent.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1eced1a6acf836a5d8916585c13087c987d6c7ec070d020e2347dd06cdb33ae
-size 91
+oid sha256:3955d2809fbd378dee6aa0f1f4afbb16f1075ba3c3f3cc30b235ccb11ca80ff6
+size 93

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithPercent10.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithPercent10.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:595a11891dca2657e14cc2b906b810f6d6089f00f552193cc597066c5b5de43d
+oid sha256:24d8f1d116c3a874ca89e86d48017d820911ef1940fd5ec179342296d1b4dcdc
 size 99

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithPercent10Transparent.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithPercent10Transparent.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d69e73b2793eef700ac9bea010e8f40d9c588ebd34428d4bb2505b3ebe91190
+oid sha256:2b7683887533551472c6576ccca172ecdc4d3bd5eae78a4a414a853e64b7def0
 size 99

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithPercent20.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithPercent20.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a34da0f8310f7d90c8d571d08502794f984d63d74f24e2e0e26a2bc1768b0315
-size 94
+oid sha256:595a11891dca2657e14cc2b906b810f6d6089f00f552193cc597066c5b5de43d
+size 99

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithPercent20Transparent.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithPercent20Transparent.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:80c73db0b7f4e6b76a56bcb893cfa65f7da0a113751c505d0b0953618bc1763e
-size 94
+oid sha256:6d69e73b2793eef700ac9bea010e8f40d9c588ebd34428d4bb2505b3ebe91190
+size 99

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithVertical.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithVertical.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f4c4ecd5a396025b3868859e2ddfcbdd7943b2494bf0b31c35d467097abccf96
+oid sha256:a368abfc419c3cae1ec38d281484ffc1234d6b4763ef1c89642afdb648de7d2a
 size 90

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithVerticalTransparent.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPatternBrushImageShouldBeFloodFilledWithVerticalTransparent.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c624408bb46eacdd6795a4d6738315a457d74f6b3ee8ad24c87802fd58da1029
+oid sha256:58e63aae0a71ac564dc91292199070c7b70a9e7621db39bcbf9e8910dee11e87
 size 90

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPolygon_Pattern_Rgba32.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/FillPolygon_Pattern_Rgba32.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8245a6b867e12a5faadc71d4337aa29e8e3093380c0e7ee739b352e8a0f6f357
-size 1871
+oid sha256:b92134da9e092de524f1c0006e9a3af2db74bf69728c36dc4c7237360f932813
+size 1281

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/HatchPatternBrushes_RenderGallery.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/HatchPatternBrushes_RenderGallery.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95b45a768fcb7a4d2e0fd8e436b74cdb35118fd47c1a337ac6967e881c3bcd42
+size 4872

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/PathAndTextDrawingMatch_Rgba32_Solid1000x1000_(255,255,255,255).png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/PathAndTextDrawingMatch_Rgba32_Solid1000x1000_(255,255,255,255).png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:078b4e6adadd5b12796180d0498bc3e981db1bf89c753f4412cbb39bbeb65fbc
-size 36212
+oid sha256:9e0766a586c335eb362211407cbc261e5c1bab28515f15b162ff91738627eede
+size 36780

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithPatternBrush_Diagonal_MatchesDefaultOutput_Default.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithPatternBrush_Diagonal_MatchesDefaultOutput_Default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffc0bf60ca2b80ed89a9f63d24dd01abdab8e6c575b73dda660a2307b3d6910f
-size 2200
+oid sha256:ced44a832fcce053dfd118d7959a7468823c8fb083573bb7d68930f505b0a0dc
+size 2085

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithPatternBrush_Diagonal_MatchesDefaultOutput_WebGPU_NativeSurface.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithPatternBrush_Diagonal_MatchesDefaultOutput_WebGPU_NativeSurface.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:02749f783c8c65de88392a9514ee466807610165a030be7f4554ab00e53f28be
-size 2140
+oid sha256:026e23fe75ae773b53c6063d3555acc50aba0f2c53beff2fd2c09467bd22331a
+size 2052

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithPatternBrush_MatchesDefaultOutput_Horizontal_Default.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithPatternBrush_MatchesDefaultOutput_Horizontal_Default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd8a2d93a0306cf23bb1138b31d8fac263cf6bca49dea577d4caf2ff4bb52cbb
-size 146
+oid sha256:b10c9935727ea60fce6d8b2c554c19333978a999021510b1dc53e0db87c8d54c
+size 145

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithPatternBrush_MatchesDefaultOutput_Horizontal_WebGPU_NativeSurface.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithPatternBrush_MatchesDefaultOutput_Horizontal_WebGPU_NativeSurface.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd8a2d93a0306cf23bb1138b31d8fac263cf6bca49dea577d4caf2ff4bb52cbb
-size 146
+oid sha256:b10c9935727ea60fce6d8b2c554c19333978a999021510b1dc53e0db87c8d54c
+size 145


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Add a new large collection of 8x8 boolean hatch masks (derived from GDI+ pixel extraction technique) to provide many hatch patterns. Fixes incorrectly implemented existing pattern brushes.

<!-- Thanks for contributing to ImageSharp.Drawing! -->
