### PR TITLE
Translate clip paths for text with RenderLocation. 

### DIFF
--- a/src/ImageSharp.Drawing/Processing/DrawingCanvas{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/DrawingCanvas{TPixel}.cs
@@ -1341,6 +1341,21 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
             ? drawingOptions
             : new DrawingOptions(graphicsOptions, shapeOptions, Matrix4x4.Identity);
 
+        IReadOnlyList<IPath>? operationClipPaths = clipPaths;
+        if (clipPaths != null && clipPaths.Count > 0 && (operation.RenderLocation.X != 0 || operation.RenderLocation.Y != 0))
+        {
+            IPath[] translatedClipPaths = new IPath[clipPaths.Count];
+
+            // Text glyph paths are queued in glyph-local coordinates and placed with RenderLocation,
+            // so canvas-space clip paths must be moved into that same local space before clipping.
+            for (int i = 0; i < clipPaths.Count; i++)
+            {
+                translatedClipPaths[i] = clipPaths[i].Translate(-operation.RenderLocation);
+            }
+
+            operationClipPaths = translatedClipPaths;
+        }
+
         if (pen is null)
         {
             return new PathCompositionSceneCommand(
@@ -1351,7 +1366,7 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
                     in rasterizerOptions,
                     state.TargetBounds,
                     destinationOffset,
-                    clipPaths,
+                    operationClipPaths,
                     state.IsLayer));
         }
 
@@ -1364,7 +1379,7 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
                 state.TargetBounds,
                 destinationOffset,
                 pen,
-                clipPaths,
+                operationClipPaths,
                 state.IsLayer));
     }
 

--- a/tests/ImageSharp.Drawing.Tests/Issues/Issue_397.cs
+++ b/tests/ImageSharp.Drawing.Tests/Issues/Issue_397.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.Fonts;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Drawing.Tests.Issues;
+
+public class Issue_397
+{
+    [Theory]
+    [WithBlankImage(240, 160, PixelTypes.Rgba32, BooleanOperation.Intersection)]
+    [WithBlankImage(240, 160, PixelTypes.Rgba32, BooleanOperation.Union)]
+    [WithBlankImage(240, 160, PixelTypes.Rgba32, BooleanOperation.Difference)]
+    [WithBlankImage(240, 160, PixelTypes.Rgba32, BooleanOperation.Xor)]
+    public void DrawTextWithIntersectingClip<TPixel>(
+        TestImageProvider<TPixel> provider,
+        BooleanOperation operation)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        PointF textOrigin = new(54, 78);
+        PointF clipCenter = new(104, 70);
+        DrawingOptions clipOptions = CreateClipOptions(operation);
+        Font font = TestFontUtilities.GetFont("OpenSans-Regular.ttf", 18);
+
+        // Expected output:
+        // - Intersection shows only red text inside the moved star.
+        // - Difference shows only red text outside the moved star.
+        // - Union and Xor can show a red star because the boolean-combined path includes the clip path,
+        //   and DrawText fills that combined result with the text brush.
+        provider.RunValidatingProcessorTest(
+            x => x.Paint(canvas => DrawIssue397Sample(canvas, clipOptions, clipCenter, textOrigin, font)),
+            testOutputDetails: $"{operation}_IntersectingClip",
+            appendPixelTypeToFileName: false,
+            appendSourceFileOrDescription: false);
+    }
+
+    [Theory]
+    [WithBlankImage(240, 160, PixelTypes.Rgba32, BooleanOperation.Intersection)]
+    [WithBlankImage(240, 160, PixelTypes.Rgba32, BooleanOperation.Union)]
+    [WithBlankImage(240, 160, PixelTypes.Rgba32, BooleanOperation.Difference)]
+    [WithBlankImage(240, 160, PixelTypes.Rgba32, BooleanOperation.Xor)]
+    public void DrawTextWithNonIntersectingClip<TPixel>(
+        TestImageProvider<TPixel> provider,
+        BooleanOperation operation)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        PointF textOrigin = new(54, 78);
+        PointF clipCenter = new(192, 116);
+        DrawingOptions clipOptions = CreateClipOptions(operation);
+        Font font = TestFontUtilities.GetFont("OpenSans-Regular.ttf", 18);
+
+        // Expected output:
+        // - Intersection shows no red text because the moved star and text do not overlap.
+        // - Difference shows the full red text because the moved star removes nothing from it.
+        // - Union and Xor show both the full red text and a red star because disjoint Xor matches Union,
+        //   and DrawText fills the boolean-combined result with the text brush.
+        provider.RunValidatingProcessorTest(
+            x => x.Paint(canvas => DrawIssue397Sample(canvas, clipOptions, clipCenter, textOrigin, font)),
+            testOutputDetails: $"{operation}_NonIntersectingClip",
+            appendPixelTypeToFileName: false,
+            appendSourceFileOrDescription: false);
+    }
+
+    private static void DrawIssue397Sample(
+        DrawingCanvas canvas,
+        DrawingOptions clipOptions,
+        PointF clipCenter,
+        PointF textOrigin,
+        Font font)
+    {
+        canvas.Clear(Brushes.Solid(Color.White));
+        StarPolygon clipPath = new(clipCenter, 7, 16, 38, 18);
+        RichTextOptions textOptions = new(font)
+        {
+            Origin = textOrigin
+        };
+
+        // The gray outline is the unclipped text guide; the red draw below shows the boolean clip result.
+        canvas.DrawText(textOptions, "This is a test", brush: null, Pens.Solid(Color.LightGray, 1F));
+
+        // The blue outline marks the moved clipping path without adding a filled shape behind the text.
+        canvas.Draw(Pens.Solid(Color.DarkBlue, 1F), clipPath);
+        canvas.Save(clipOptions, clipPath);
+
+        canvas.DrawText(
+            textOptions,
+            "This is a test",
+            Brushes.Solid(Color.Crimson),
+            pen: null);
+
+        canvas.Restore();
+        canvas.Draw(Pens.Solid(Color.DarkBlue, 1F), clipPath);
+    }
+
+    private static DrawingOptions CreateClipOptions(BooleanOperation operation)
+        => new()
+        {
+            ShapeOptions = new()
+            {
+                BooleanOperation = operation
+            }
+        };
+}

--- a/tests/Images/ReferenceOutput/Issue_397/DrawTextWithIntersectingClip_Difference_IntersectingClip.png
+++ b/tests/Images/ReferenceOutput/Issue_397/DrawTextWithIntersectingClip_Difference_IntersectingClip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43fb26b0590be0f4f41fa82445e9c8754bbaab493e1dbb8d93002ffdc5d34dab
+size 4675

--- a/tests/Images/ReferenceOutput/Issue_397/DrawTextWithIntersectingClip_Intersection_IntersectingClip.png
+++ b/tests/Images/ReferenceOutput/Issue_397/DrawTextWithIntersectingClip_Intersection_IntersectingClip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e2a5d7e5d6b53950f7bd79a2bdbba48c2d373103ef9d3ffa7025388f34472df
+size 4277

--- a/tests/Images/ReferenceOutput/Issue_397/DrawTextWithIntersectingClip_Union_IntersectingClip.png
+++ b/tests/Images/ReferenceOutput/Issue_397/DrawTextWithIntersectingClip_Union_IntersectingClip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff89de4bec0856bd6e05bba4c26bbf77de2d978eaeb0aa76772bf2d41863cf9d
+size 6205

--- a/tests/Images/ReferenceOutput/Issue_397/DrawTextWithIntersectingClip_Xor_IntersectingClip.png
+++ b/tests/Images/ReferenceOutput/Issue_397/DrawTextWithIntersectingClip_Xor_IntersectingClip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ea6f78b35838ac8e03f9ed74ae974349805a15f1f74f55a16fb2407ec20c911
+size 6205

--- a/tests/Images/ReferenceOutput/Issue_397/DrawTextWithNonIntersectingClip_Difference_NonIntersectingClip.png
+++ b/tests/Images/ReferenceOutput/Issue_397/DrawTextWithNonIntersectingClip_Difference_NonIntersectingClip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3125d65a6a97d1b0e7752fe63cab529007e2acbd6658c06905ccef0de4a52bd
+size 4820

--- a/tests/Images/ReferenceOutput/Issue_397/DrawTextWithNonIntersectingClip_Intersection_NonIntersectingClip.png
+++ b/tests/Images/ReferenceOutput/Issue_397/DrawTextWithNonIntersectingClip_Intersection_NonIntersectingClip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:305803eab9be305f26cbed0b55dadbe022830d577c65d36624a32bc17395d009
+size 2823

--- a/tests/Images/ReferenceOutput/Issue_397/DrawTextWithNonIntersectingClip_Union_NonIntersectingClip.png
+++ b/tests/Images/ReferenceOutput/Issue_397/DrawTextWithNonIntersectingClip_Union_NonIntersectingClip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d763346286309775c8c5d2a6353cf387ad6b44ac29900a036de43c49106a68ef
+size 6922

--- a/tests/Images/ReferenceOutput/Issue_397/DrawTextWithNonIntersectingClip_Xor_NonIntersectingClip.png
+++ b/tests/Images/ReferenceOutput/Issue_397/DrawTextWithNonIntersectingClip_Xor_NonIntersectingClip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d763346286309775c8c5d2a6353cf387ad6b44ac29900a036de43c49106a68ef
+size 6922


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #397

This pull request addresses a bug in how clipping paths are applied when rendering text with a positional offset, ensuring that clip paths are correctly transformed into the text's local coordinate space. It also adds comprehensive regression tests to validate the fix for various boolean clip operations and provides new reference images for test verification.

**Bug Fixes:**

* Corrected the transformation of `clipPaths` in `DrawingCanvas<TPixel>.CreateTextCompositionCommand` so that when text is rendered with a non-zero `RenderLocation`, the clip paths are translated into the glyph-local coordinate space, ensuring correct clipping behavior. [[1]](diffhunk://#diff-3af9bffd557c8a401d9cd65f27ab378a252134b774e0bcf9d1fb11dc16d9427eR1344-R1358) [[2]](diffhunk://#diff-3af9bffd557c8a401d9cd65f27ab378a252134b774e0bcf9d1fb11dc16d9427eL1354-R1369) [[3]](diffhunk://#diff-3af9bffd557c8a401d9cd65f27ab378a252134b774e0bcf9d1fb11dc16d9427eL1367-R1382)

**Testing Improvements:**

* Added a new test class `Issue_397` to cover scenarios where text is drawn with intersecting and non-intersecting clipping paths using all boolean operations, validating both the fix and expected rendering output.
* Added reference output images for all test cases in `Issue_397` to support regression testing and visual verification. [[1]](diffhunk://#diff-159cd187c226970a9db3112c8b2128bd5a2296c50ed2f55c9c9a3183577ae57fR1-R3) [[2]](diffhunk://#diff-2cb169584307e10fe0ab34e0495d1cb853de0f3dc3f12fd5022cd8e050dd3194R1-R3) [[3]](diffhunk://#diff-ce9fdcab05bbbf575c1e6e0d801904e6f0d5f6d380c31010ab137c0cb5683136R1-R3) [[4]](diffhunk://#diff-90b13b1dd68d64d79ae7dfd69c7278be40333246e468ae8a940fe8f9f1aced38R1-R3) [[5]](diffhunk://#diff-86f78f932dd6195b5d4129b342420bffb97ea50dddaef02541d02a8a0d1ed88eR1-R3) [[6]](diffhunk://#diff-90df4bac897e40cb82baab132c36533e0cd94e7d1c4a9e7ff360f8448b094393R1-R3) [[7]](diffhunk://#diff-8b4843a61285230be7cf86cef23173ff93050324e9ce20422d4f88616e338158R1-R3)
<!-- Thanks for contributing to ImageSharp.Drawing! -->
