### PR TITLE
COLRv1 group rendering, zero-callback layered glyph cache, WebGPU blend parity and CPU-exact brush colors

### DIFF
--- a/src/ImageSharp.Drawing.WebGPU/Shaders/FineAreaComputeShader.cs
+++ b/src/ImageSharp.Drawing.WebGPU/Shaders/FineAreaComputeShader.cs
@@ -160,15 +160,21 @@ internal static class FineAreaComputeShader
         // The CPU RecolorBrush observes a TPixel already written by earlier draws. A staged GPU
         // scene keeps those draws in f32 registers, so Recolor alone must reproduce the target's
         // physical storage conversion before comparing without reducing normal composition precision.
+        // Binary16 quantization must round to nearest even like the CPU renderer's
+        // float-to-half conversion; pack2x16float and the hardware store may truncate
+        // toward zero, so the round trip routes through the explicit RTNE helper.
         string targetFormatRoundTripBody = textureFormat switch
         {
             WGPUTextureFormat.RGBA8Unorm or WGPUTextureFormat.BGRA8Unorm => "return unpack4x8unorm(pack4x8unorm(color));",
             WGPUTextureFormat.RGBA8Snorm => "return unpack4x8snorm(pack4x8snorm(color));",
-            WGPUTextureFormat.RGBA16Float => "return vec4<f32>(unpack2x16float(pack2x16float(color.rg)), unpack2x16float(pack2x16float(color.ba)));"
+            WGPUTextureFormat.RGBA16Float => "return vec4<f32>(quantize_f16_rtne(color.x), quantize_f16_rtne(color.y), quantize_f16_rtne(color.z), quantize_f16_rtne(color.w));"
         };
 
-        // Fine shading uses associated colors internally. Recolor explicitly crosses the target
-        // TPixel storage boundary, including associated-alpha rescaling when stored alpha quantizes.
+        // Fine shading uses associated colors internally. Unassociated targets cross the storage
+        // boundary with Numerics.UnPremultiply's exact semantics: zero alpha preserves RGB, and a
+        // true division (not a reciprocal multiply) rounds identically to the CPU renderer.
+        // Recolor additionally crosses the target TPixel storage boundary, including
+        // associated-alpha rescaling when stored alpha quantizes.
         (string Decode, string Encode, string RecolorNativeToInternal, string RecolorStoreTarget) alphaBodies = alphaRepresentation switch
         {
             PixelAlphaRepresentation.Associated =>
@@ -180,14 +186,40 @@ internal static class FineAreaComputeShader
             PixelAlphaRepresentation.Unassociated =>
                 (
                     "return premul_alpha(decode_numeric(color));",
-                    "let a_inv = select(0.0, 1.0 / color.a, color.a > 0.0);\n    return encode_numeric(vec4<f32>(color.rgb * a_inv, color.a));",
+                    "if color.a == 0.0 {\n        return encode_numeric(color);\n    }\n\n    return encode_numeric(vec4<f32>(color.rgb / color.a, color.a));",
                     "return premul_alpha(color);",
-                    "let a_inv = select(0.0, 1.0 / color.a, color.a > 0.0);\n    let native = vec4<f32>(color.rgb * a_inv, color.a);\n    return decode_numeric(round_trip_target_format(encode_numeric(native)));")
+                    "if color.a == 0.0 {\n        return decode_numeric(round_trip_target_format(encode_numeric(color)));\n    }\n\n    let native = vec4<f32>(color.rgb / color.a, color.a);\n    return decode_numeric(round_trip_target_format(encode_numeric(native)));")
         };
 #pragma warning restore CS8509, CS8524
 
         string targetConversionFunctions =
             $$"""
+            fn quantize_f16_rtne(value: f32) -> f32 {
+                // Binary16 quantization with IEEE round-to-nearest-even. pack2x16float and the
+                // hardware f32-to-f16 store conversion may truncate toward zero, so the two
+                // bracketing half values are recovered by bit stepping (monotonic for one sign)
+                // and the nearest is chosen, ties to the even mantissa, matching the CPU
+                // renderer's float-to-half conversion exactly.
+                let magnitude = abs(value);
+                let packed = pack2x16float(vec2(magnitude, 0.0)) & 0xffffu;
+                let snapped = unpack2x16float(packed).x;
+                if snapped == magnitude {
+                    return select(snapped, -snapped, value < 0.0);
+                }
+
+                let lower_bits = select(packed, packed - 1u, snapped > magnitude);
+                let lower = unpack2x16float(lower_bits).x;
+                let upper = unpack2x16float(lower_bits + 1u).x;
+                let below = magnitude - lower;
+                let above = upper - magnitude;
+                var rounded = lower;
+                if above < below || (above == below && (lower_bits & 1u) == 1u) {
+                    rounded = upper;
+                }
+
+                return select(rounded, -rounded, value < 0.0);
+            }
+
             fn decode_numeric(color: vec4<f32>) -> vec4<f32> {
                 {{numericBodies.Decode}}
             }
@@ -220,16 +252,29 @@ internal static class FineAreaComputeShader
                 return color;
             }
 
-            fn pack_clip_color(color: vec4<f32>) -> vec2<u32> {
-                return vec2<u32>(pack2x16float(color.rg), pack2x16float(color.ba));
+            fn pack_clip_color(color: vec4<f32>) -> vec4<u32> {
+                // The clip stack preserves the backdrop across isolated layer pops, where
+                // per-draw blend modes composite against it. The CPU renderer composes
+                // against the exact target value, so the save must be bit-lossless:
+                // binary16 packing here shifts results near storage rounding boundaries.
+                return bitcast<vec4<u32>>(color);
             }
 
-            fn unpack_clip_color(color: vec2<u32>) -> vec4<f32> {
-                return vec4<f32>(unpack2x16float(color.x), unpack2x16float(color.y));
+            fn unpack_clip_color(color: vec4<u32>) -> vec4<f32> {
+                return bitcast<vec4<f32>>(color);
             }
             """;
 
-        return new ShaderTraits(compositeTraits.OutputFormat, targetConversionFunctions, "textureStore(output, vec2<i32>(coords), encode_target(rgba[i]));");
+        // Every store quantizes in-shader first: hardware store conversions carry slack the
+        // CPU renderer does not (f32-to-f16 may truncate toward zero, float-to-unorm allows
+        // up to 0.6 ULP of error), while the spec-defined pack builtins and the explicit
+        // binary16 helper round exactly like the CPU's pixel packing. Passing an exactly
+        // representable value makes the hardware conversion lossless, so both backends
+        // store identical pixels.
+        return new ShaderTraits(
+            compositeTraits.OutputFormat,
+            targetConversionFunctions,
+            "textureStore(output, vec2<i32>(coords), round_trip_target_format(encode_target(rgba[i])));");
     }
 
     /// <summary>

--- a/src/ImageSharp.Drawing.WebGPU/Shaders/WgslSource/Shared/blend.wgsl
+++ b/src/ImageSharp.Drawing.WebGPU/Shaders/WgslSource/Shared/blend.wgsl
@@ -1,14 +1,24 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
-// Color mixing and compositing math for layer blending.
+// Color mixing and compositing math for draw and layer blending.
 //
-// Imported by fine.wgsl, which calls blend_mix_compose when popping a clip or
-// layer (CMD_END_CLIP) to combine the layer contents with its backdrop. The
-// math mirrors the CPU drawing backend's blending so both backends produce
-// the same output for a given GraphicsOptions.
+// Imported by fine.wgsl for per-draw composition (compose_draw), recolor
+// inner blends, and layer pops (CMD_END_CLIP). ImageSharp's CPU renderer is
+// the parity authority for every formula, branch, and operand order below:
 //
-// Ported from Vello's shader/shared/blend.wgsl (linebender/vello).
+//   - AssociatedAlphaPorterDuffFunctions: composition operators and the
+//     associated overlap terms.
+//   - AssociatedAlphaPorterDuffFunctions.Generated: the mode-to-operator
+//     mapping and the opacity application.
+//   - PorterDuffFunctions: the straight-RGB blend curves (ColorDodge through
+//     Luminosity) together with SetSaturation, SetLuminosity, and Luminosity.
+//   - Numerics.UnPremultiply: zero-alpha semantics for straight recovery.
+//
+// Colors are associated (premultiplied) on input and output throughout.
+// Straight RGB is recovered only inside the blend modes whose CPU equations
+// are defined on straight colors, at the same point, and re-associated in
+// the same order, as the CPU implementation.
 
 // Color mixing modes.
 //
@@ -16,8 +26,7 @@
 // produced by WebGPUSceneEncoder.PackBlendMode, so every value documents the
 // wire format shared with the C# encoder even where no WGSL code names it.
 // The values mirror the CSS mix-blend-mode list from Vello; the C# encoder
-// currently emits only NORMAL, MULTIPLY, SCREEN, OVERLAY, DARKEN, LIGHTEN,
-// HARD_LIGHT, ADD, and SUBTRACT.
+// emits every ImageSharp PixelColorBlendingMode value.
 
 const MIX_NORMAL = 0u;
 const MIX_MULTIPLY = 1u;
@@ -39,18 +48,26 @@ const MIX_COLOR = 14u;
 const MIX_LUMINOSITY = 15u;
 // Wire value written by the C# encoder (WebGPUSceneEncoder.ClipBlendMode) to
 // mark a pure clip layer. As the mix half of the packed word it occupies bit
-// 15, which blend_mix_compose masks off so clip layers take the plain
-// src-over fast path. No WGSL code names this constant; it documents the
-// wire format shared with the encoder.
+// 15, which compose_source masks off so clip layers take the plain
+// normal source-over fast path. No WGSL code names this constant; it
+// documents the wire format shared with the encoder.
 const MIX_CLIP = 128u;
 
-// Screen blend: inverted multiply of the inverted channels.
-fn screen(cb: vec3<f32>, cs: vec3<f32>) -> vec3<f32> {
-    return cb + cs - (cb * cs);
+// Converts an associated color to straight RGB. Mirrors
+// Numerics.UnPremultiply: zero alpha has no mathematical inverse, so the
+// stored RGB passes through unchanged instead of collapsing to zero.
+fn unpremultiply(color: vec4<f32>) -> vec3<f32> {
+    if color.a == 0.0 {
+        return color.rgb;
+    }
+
+    return color.rgb / color.a;
 }
 
-// Per-channel color-dodge blend. The zero and one cases are handled
-// explicitly to avoid the division blowing up.
+// Per-channel color-dodge blend (PorterDuffFunctions.ColorDodgeValue). The
+// singular zero-backdrop and one-source cases are resolved before the
+// division, in the CPU's precedence order, so transparent or saturated
+// channels never divide by zero.
 fn color_dodge(cb: f32, cs: f32) -> f32 {
     if cb == 0.0 {
         return 0.0;
@@ -61,7 +78,8 @@ fn color_dodge(cb: f32, cs: f32) -> f32 {
     }
 }
 
-// Per-channel color-burn blend, the dual of color_dodge.
+// Per-channel color-burn blend (PorterDuffFunctions.ColorBurnValue), the dual
+// of color_dodge with the same explicit singular handling.
 fn color_burn(cb: f32, cs: f32) -> f32 {
     if cb == 1.0 {
         return 1.0;
@@ -72,18 +90,10 @@ fn color_burn(cb: f32, cs: f32) -> f32 {
     }
 }
 
-// Hard-light blend: multiply for dark source channels, screen for light ones.
-// Overlay is implemented as hard_light with the operands swapped.
-fn hard_light(cb: vec3<f32>, cs: vec3<f32>) -> vec3<f32> {
-    return select(
-        screen(cb, 2.0 * cs - 1.0),
-        cb * 2.0 * cs,
-        cs <= vec3(0.5)
-    );
-}
-
-// Soft-light blend per the W3C compositing spec, using the piecewise
-// polynomial approximation of the darkening curve for cb <= 0.25.
+// Soft-light blend (PorterDuffFunctions.SoftLightValue): multiply-like
+// darkening for source <= 0.5, otherwise a lightening curve whose cubic
+// segment below backdrop 0.25 joins the square-root segment smoothly while
+// avoiding its steep slope near zero.
 fn soft_light(cb: vec3<f32>, cs: vec3<f32>) -> vec3<f32> {
     let d = select(
         sqrt(cb),
@@ -97,16 +107,17 @@ fn soft_light(cb: vec3<f32>, cs: vec3<f32>) -> vec3<f32> {
     );
 }
 
-// Saturation of a color: the spread between its largest and smallest channel.
+// Saturation of a straight color (PorterDuffFunctions.Saturation): the spread
+// between its largest and smallest channel.
 fn sat(c: vec3<f32>) -> f32 {
     return max(c.x, max(c.y, c.z)) - min(c.x, min(c.y, c.z));
 }
 
-// Luminosity using the NTSC weights specified by the W3C compositing spec
-// for the non-separable blend modes.
+// Luminosity of a straight color (PorterDuffFunctions.Luminosity). The
+// explicit scalar operation order is kept because a dot() product may be
+// contracted differently by a shader compiler.
 fn lum(c: vec3<f32>) -> f32 {
-    let f = vec3(0.3, 0.59, 0.11);
-    return dot(c, f);
+    return (0.3 * c.x) + (0.59 * c.y) + (0.11 * c.z);
 }
 
 // Luminance using the SVG/Rec. 709 coefficients. Used by fine.wgsl to build
@@ -116,137 +127,80 @@ fn svg_lum(c: vec3<f32>) -> f32 {
     return dot(c, f);
 }
 
-// Clamps an out-of-gamut color back into [0, 1] by scaling its channels
-// toward the luminosity, preserving perceived lightness (spec ClipColor).
-fn clip_color(c_in: vec3<f32>) -> vec3<f32> {
-    var c = c_in;
-    let l = lum(c);
-    let n = min(c.x, min(c.y, c.z));
-    let x = max(c.x, max(c.y, c.z));
-    if n < 0.0 {
-        c = l + (((c - l) * l) / (l - n));
+// Replaces the saturation of a color (PorterDuffFunctions.SetSaturation).
+// Translating the minimum to zero and scaling the range is equivalent to the
+// specification's ordered-channel construction; the CPU's scalar-ratio order
+// is kept so both backends round identically.
+fn set_sat(c: vec3<f32>, s: f32) -> vec3<f32> {
+    let minimum = min(c.x, min(c.y, c.z));
+    let range = max(c.x, max(c.y, c.z)) - minimum;
+    if range == 0.0 {
+        return vec3(0.0);
     }
-    if x > 1.0 {
-        c = l + (((c - l) * (1.0 - l)) / (x - l));
+
+    return (c - vec3(minimum)) * (s / range);
+}
+
+// Replaces the luminosity of a color and clips the result to the
+// representable gamut (PorterDuffFunctions.SetLuminosity). Out-of-gamut
+// channels are pulled toward the requested luminosity by one shared ratio so
+// hue is preserved. The clip anchors on the requested luminosity l, not a
+// recomputed one, exactly as the CPU does.
+fn set_lum(c_in: vec3<f32>, l: f32) -> vec3<f32> {
+    var c = c_in + vec3(l - lum(c_in));
+
+    let minimum = min(c.x, min(c.y, c.z));
+    if minimum < 0.0 {
+        c = vec3(l) + ((c - vec3(l)) * (l / (l - minimum)));
     }
+
+    let maximum = max(c.x, max(c.y, c.z));
+    if maximum > 1.0 {
+        c = vec3(l) + ((c - vec3(l)) * ((1.0 - l) / (maximum - l)));
+    }
+
     return c;
 }
 
-// Shifts a color to the target luminosity, then re-clips into gamut.
-fn set_lum(c: vec3<f32>, l: f32) -> vec3<f32> {
-    return clip_color(c + (l - lum(c)));
-}
-
-// Rescales three channel values, already ordered min/mid/max, so that the
-// spread becomes s while the mid channel keeps its relative position.
-fn set_sat_inner(
-    cmin: ptr<function, f32>,
-    cmid: ptr<function, f32>,
-    cmax: ptr<function, f32>,
-    s: f32
-) {
-    if *cmax > *cmin {
-        *cmid = ((*cmid - *cmin) * s) / (*cmax - *cmin);
-        *cmax = s;
-    } else {
-        *cmid = 0.0;
-        *cmax = 0.0;
-    }
-    *cmin = 0.0;
-}
-
-// Sets the saturation of a color to s (spec SetSat). The branch ladder
-// orders the channels so set_sat_inner receives them as min/mid/max.
-fn set_sat(c: vec3<f32>, s: f32) -> vec3<f32> {
-    var r = c.r;
-    var g = c.g;
-    var b = c.b;
-    if r <= g {
-        if g <= b {
-            set_sat_inner(&r, &g, &b, s);
-        } else {
-            if r <= b {
-                set_sat_inner(&r, &b, &g, s);
-            } else {
-                set_sat_inner(&b, &r, &g, s);
-            }
-        }
-    } else {
-        if r <= b {
-            set_sat_inner(&g, &r, &b, s);
-        } else {
-            if g <= b {
-                set_sat_inner(&g, &b, &r, s);
-            } else {
-                set_sat_inner(&b, &g, &r, s);
-            }
-        }
-    }
-    return vec3(r, g, b);
-}
-
-// Blends two RGB colors together using the given MIX_* mode. The colors are
-// assumed to be in sRGB color space, and this function does not take alpha
-// into account; unknown modes (including MIX_NORMAL) return the source.
+// Straight-RGB blend curves for the modes whose CPU equations are defined on
+// straight colors (PorterDuffFunctions.ColorDodge through Luminosity). cb and
+// cs are the straight backdrop and source recovered by the caller, and the
+// straight result is re-associated by the caller. The separable legacy modes
+// never reach this function; their overlap terms stay associated in
+// blend_overlap.
 fn blend_mix(cb: vec3<f32>, cs: vec3<f32>, mode: u32) -> vec3<f32> {
-    var b = vec3(0.0);
     switch mode {
-        case MIX_MULTIPLY: {
-            b = cb * cs;
-        }
-        case MIX_SCREEN: {
-            b = screen(cb, cs);
-        }
-        case MIX_OVERLAY: {
-            b = hard_light(cs, cb);
-        }
-        case MIX_DARKEN: {
-            b = min(cb, cs);
-        }
-        case MIX_LIGHTEN: {
-            b = max(cb, cs);
-        }
-        case MIX_ADD: {
-            b = min(vec3(1.0), cb + cs);
-        }
-        case MIX_SUBTRACT: {
-            b = max(vec3(0.0), cb - cs);
-        }
         case MIX_COLOR_DODGE: {
-            b = vec3(color_dodge(cb.x, cs.x), color_dodge(cb.y, cs.y), color_dodge(cb.z, cs.z));
+            return vec3(color_dodge(cb.x, cs.x), color_dodge(cb.y, cs.y), color_dodge(cb.z, cs.z));
         }
         case MIX_COLOR_BURN: {
-            b = vec3(color_burn(cb.x, cs.x), color_burn(cb.y, cs.y), color_burn(cb.z, cs.z));
-        }
-        case MIX_HARD_LIGHT: {
-            b = hard_light(cb, cs);
+            return vec3(color_burn(cb.x, cs.x), color_burn(cb.y, cs.y), color_burn(cb.z, cs.z));
         }
         case MIX_SOFT_LIGHT: {
-            b = soft_light(cb, cs);
+            return soft_light(cb, cs);
         }
         case MIX_DIFFERENCE: {
-            b = abs(cb - cs);
+            return abs(cb - cs);
         }
         case MIX_EXCLUSION: {
-            b = cb + cs - 2.0 * cb * cs;
+            return cb + cs - 2.0 * cb * cs;
         }
         case MIX_HUE: {
-            b = set_lum(set_sat(cs, sat(cb)), lum(cb));
+            return set_lum(set_sat(cs, sat(cb)), lum(cb));
         }
         case MIX_SATURATION: {
-            b = set_lum(set_sat(cb, sat(cs)), lum(cb));
+            return set_lum(set_sat(cb, sat(cs)), lum(cb));
         }
         case MIX_COLOR: {
-            b = set_lum(cs, lum(cb));
+            return set_lum(cs, lum(cb));
         }
         case MIX_LUMINOSITY: {
-            b = set_lum(cb, lum(cs));
+            return set_lum(cb, lum(cs));
         }
         default: {
-            b = cs;
+            return cs;
         }
     }
-    return b;
 }
 
 // Composition modes.
@@ -271,109 +225,209 @@ const COMPOSE_XOR = 11u;
 const COMPOSE_PLUS = 12u;
 const COMPOSE_PLUS_LIGHTER = 13u;
 
-// Apply general compositing operation.
-// Inputs are separated colors and alpha, output is premultiplied.
-// fa/fb are the Porter-Duff source and backdrop fractions for the mode;
-// COMPOSE_CLEAR falls through the default with fa = fb = 0.
-fn blend_compose(
-    cb: vec3<f32>,
-    cs: vec3<f32>,
-    ab: f32,
-    as_: f32,
-    compose_mode: u32,
-) -> vec4<f32> {
-    var fa = 0.0;
-    var fb = 0.0;
+// Composition operators ported one-for-one from
+// AssociatedAlphaPorterDuffFunctions. All vectors are associated, and each
+// operand order matches the CPU's scalar Vector4 implementation so both
+// backends round identically. The overlap argument is the associated
+// color-blend term for the region where source and destination coverage
+// intersect; alpha never takes the overlap value.
+
+// AssociatedAlphaPorterDuffFunctions.OverNormal: Ps + Pb(1 - As). Color and
+// alpha share the same coefficient, so one whole-vector expression suffices.
+fn compose_over_normal(destination: vec4<f32>, source: vec4<f32>) -> vec4<f32> {
+    return source + (destination * (1.0 - source.a));
+}
+
+// AssociatedAlphaPorterDuffFunctions.Over: destination-only, source-only, and
+// blended overlap contributions, with plain source-over alpha.
+fn compose_over(destination: vec4<f32>, source: vec4<f32>, overlap: vec3<f32>) -> vec4<f32> {
+    let color = ((destination * (1.0 - source.a)) + (source * (1.0 - destination.a))).rgb + overlap;
+    let alpha = source.a + (destination.a * (1.0 - source.a));
+    return vec4(color, alpha);
+}
+
+// AssociatedAlphaPorterDuffFunctions.AtopNormal: the source replaces the
+// destination's covered contribution while total coverage stays put.
+fn compose_atop_normal(destination: vec4<f32>, source: vec4<f32>) -> vec4<f32> {
+    return (source * destination.a) + (destination * (1.0 - source.a));
+}
+
+// AssociatedAlphaPorterDuffFunctions.Atop: fused destination retention plus
+// the blended overlap; the destination alpha is preserved exactly. The CPU
+// uses a fused multiply-add here, so fma() is the closest expression.
+fn compose_atop(destination: vec4<f32>, source: vec4<f32>, overlap: vec3<f32>) -> vec4<f32> {
+    return vec4(fma(destination.rgb, vec3(1.0 - source.a), overlap), destination.a);
+}
+
+// AssociatedAlphaPorterDuffFunctions.In: retain the source inside the
+// destination coverage.
+fn compose_in(destination: vec4<f32>, source: vec4<f32>) -> vec4<f32> {
+    return source * destination.a;
+}
+
+// AssociatedAlphaPorterDuffFunctions.Out: retain the source outside the
+// destination coverage.
+fn compose_out(destination: vec4<f32>, source: vec4<f32>) -> vec4<f32> {
+    return source * (1.0 - destination.a);
+}
+
+// AssociatedAlphaPorterDuffFunctions.Xor: keep only the non-overlapping parts
+// of the two vectors.
+fn compose_xor(destination: vec4<f32>, source: vec4<f32>) -> vec4<f32> {
+    return (source * (1.0 - destination.a)) + (destination * (1.0 - source.a));
+}
+
+// AssociatedAlphaPorterDuffFunctions.PlusNormal: clamped additive
+// composition without a color-blending function.
+fn compose_plus_normal(destination: vec4<f32>, source: vec4<f32>) -> vec4<f32> {
+    let alpha = min(1.0, source.a + destination.a);
+    return vec4(min(vec3(1.0), (destination + source).rgb), alpha);
+}
+
+// AssociatedAlphaPorterDuffFunctions.Plus: the blended source contributes
+// straight source color outside the destination and the overlap term inside,
+// with both color and alpha clamped to the representable range.
+fn compose_plus(destination: vec4<f32>, source: vec4<f32>, overlap: vec3<f32>) -> vec4<f32> {
+    let alpha = min(1.0, source.a + destination.a);
+    let color = (destination + (source * (1.0 - destination.a))).rgb + overlap;
+    return vec4(min(vec3(1.0), color), alpha);
+}
+
+// One associated Overlay/HardLight overlap channel group
+// (AssociatedAlphaPorterDuffFunctions.OverlayValue). Comparing 2Pb with Ab is
+// equivalent to comparing the straight backdrop channel with one half, so no
+// unpremultiply is needed. Doubling is exact in binary floating point, which
+// keeps this bit-identical to the CPU's scalar operation order.
+fn overlay_value(backdrop: vec3<f32>, backdrop_alpha: f32, source: vec3<f32>, source_alpha: f32) -> vec3<f32> {
+    let doubled = backdrop + backdrop;
+    let multiply_side = doubled * source;
+    let screen_side = vec3(backdrop_alpha * source_alpha) - (2.0 * (vec3(backdrop_alpha) - backdrop) * (vec3(source_alpha) - source));
+    return select(screen_side, multiply_side, doubled <= vec3(backdrop_alpha));
+}
+
+// The associated overlap term produced by the color-blending half of
+// AssociatedAlphaPorterDuffFunctions. The separable legacy modes stay in
+// associated arithmetic exactly as the CPU does. The straight-RGB modes
+// recover straight colors (preserving RGB at zero alpha), blend, then
+// re-associate by multiplying by backdrop alpha and then source alpha, which
+// is the CPU's exact multiplication order.
+fn blend_overlap(backdrop: vec4<f32>, source: vec4<f32>, mix_mode: u32) -> vec3<f32> {
+    switch mix_mode {
+        case MIX_MULTIPLY: {
+            return backdrop.rgb * source.rgb;
+        }
+        case MIX_ADD: {
+            return min(vec3(backdrop.a * source.a), (backdrop.rgb * source.a) + (source.rgb * backdrop.a));
+        }
+        case MIX_SUBTRACT: {
+            return max(vec3(0.0), (backdrop.rgb * source.a) - (source.rgb * backdrop.a));
+        }
+        case MIX_SCREEN: {
+            return (backdrop.rgb * source.a) + (source.rgb * backdrop.a) - (backdrop.rgb * source.rgb);
+        }
+        case MIX_DARKEN: {
+            return min(backdrop.rgb * source.a, source.rgb * backdrop.a);
+        }
+        case MIX_LIGHTEN: {
+            return max(backdrop.rgb * source.a, source.rgb * backdrop.a);
+        }
+        case MIX_OVERLAY: {
+            return overlay_value(backdrop.rgb, backdrop.a, source.rgb, source.a);
+        }
+        case MIX_HARD_LIGHT: {
+            return overlay_value(source.rgb, source.a, backdrop.rgb, backdrop.a);
+        }
+        case MIX_COLOR_DODGE, MIX_COLOR_BURN, MIX_SOFT_LIGHT, MIX_DIFFERENCE, MIX_EXCLUSION, MIX_HUE, MIX_SATURATION, MIX_COLOR, MIX_LUMINOSITY: {
+            let mixed = blend_mix(unpremultiply(backdrop), unpremultiply(source), mix_mode);
+            return (mixed * backdrop.a) * source.a;
+        }
+        default: {
+            return vec3(0.0);
+        }
+    }
+}
+
+// Composites an associated source over an associated backdrop using the
+// packed blend word ((mix << 8) | compose) and the source opacity. This is
+// the GPU equivalent of the generated AssociatedAlphaPorterDuffFunctions
+// operators: opacity scales the associated source as a whole (RGB and alpha
+// together) so it cannot change the represented straight color, Dest and
+// Clear ignore the source, and each compose mode maps to the same operator
+// family as the CPU's GetPixelBlender switch, with source-over serving as
+// the default exactly as it does on the CPU.
+fn compose_source(backdrop: vec4<f32>, source: vec4<f32>, opacity: f32, mode: u32) -> vec4<f32> {
+    // Bit 15 of the packed word carries the encoder's MIX_CLIP marker;
+    // stripping it lets pure clip layers take the normal source-over path.
+    let mix_mode = (mode >> 8u) & 0x7fu;
+    let compose_mode = mode & 0xffu;
+    let scaled = source * opacity;
+
+    // Normal source-over dominates real scenes, so resolve it before the
+    // switch. The formula is compose_over_normal exactly.
+    if compose_mode == COMPOSE_SRC_OVER && mix_mode == MIX_NORMAL {
+        return scaled + (backdrop * (1.0 - scaled.a));
+    }
+
+    let normal = mix_mode == MIX_NORMAL;
     switch compose_mode {
+        case COMPOSE_CLEAR: {
+            return vec4(0.0);
+        }
         case COMPOSE_COPY: {
-            fa = 1.0;
-            fb = 0.0;
+            return scaled;
         }
         case COMPOSE_DEST: {
-            fa = 0.0;
-            fb = 1.0;
-        }
-        case COMPOSE_SRC_OVER: {
-            fa = 1.0;
-            fb = 1.0 - as_;
+            return backdrop;
         }
         case COMPOSE_DEST_OVER: {
-            fa = 1.0 - ab;
-            fb = 1.0;
+            if normal {
+                return compose_over_normal(scaled, backdrop);
+            }
+
+            return compose_over(scaled, backdrop, blend_overlap(scaled, backdrop, mix_mode));
         }
         case COMPOSE_SRC_IN: {
-            fa = ab;
-            fb = 0.0;
+            return compose_in(backdrop, scaled);
         }
         case COMPOSE_DEST_IN: {
-            fa = 0.0;
-            fb = as_;
+            return compose_in(scaled, backdrop);
         }
         case COMPOSE_SRC_OUT: {
-            fa = 1.0 - ab;
-            fb = 0.0;
+            return compose_out(backdrop, scaled);
         }
         case COMPOSE_DEST_OUT: {
-            fa = 0.0;
-            fb = 1.0 - as_;
+            return compose_out(scaled, backdrop);
         }
         case COMPOSE_SRC_ATOP: {
-            fa = ab;
-            fb = 1.0 - as_;
+            if normal {
+                return compose_atop_normal(backdrop, scaled);
+            }
+
+            return compose_atop(backdrop, scaled, blend_overlap(backdrop, scaled, mix_mode));
         }
         case COMPOSE_DEST_ATOP: {
-            fa = 1.0 - ab;
-            fb = as_;
+            if normal {
+                return compose_atop_normal(scaled, backdrop);
+            }
+
+            return compose_atop(scaled, backdrop, blend_overlap(scaled, backdrop, mix_mode));
         }
         case COMPOSE_XOR: {
-            fa = 1.0 - ab;
-            fb = 1.0 - as_;
+            return compose_xor(backdrop, scaled);
         }
         case COMPOSE_PLUS: {
-            fa = 1.0;
-            fb = 1.0;
-        }
-        case COMPOSE_PLUS_LIGHTER: {
-            return min(vec4(1.0), vec4(as_ * cs + ab * cb, as_ + ab));
-        }
-        default: {}
-    }
-    let as_fa = as_ * fa;
-    let ab_fb = ab * fb;
-    let co = as_fa * cs + ab_fb * cb;
-    // Modes like COMPOSE_PLUS can generate alpha > 1.0, so clamp.
-    return vec4(co, min(as_fa + ab_fb, 1.0));
-}
+            if normal {
+                return compose_plus_normal(backdrop, scaled);
+            }
 
-// Converts a premultiplied color to separated RGB by dividing out alpha.
-fn unpremultiply(color: vec4<f32>) -> vec3<f32> {
-    let EPSILON = 1e-15;
-    // Max with a small epsilon to avoid NaNs.
-    let inv_alpha = 1.0 / max(color.a, EPSILON);
-    return color.rgb * inv_alpha;
-}
+            return compose_plus(backdrop, scaled, blend_overlap(backdrop, scaled, mix_mode));
+        }
+        default: {
+            if normal {
+                return compose_over_normal(backdrop, scaled);
+            }
 
-// Apply color mixing and composition. Both input and output colors are
-// premultiplied RGB. `mode` is the packed word (mix << 8) | compose written
-// by the C# encoder's PackBlendMode.
-fn blend_mix_compose(backdrop: vec4<f32>, src: vec4<f32>, mode: u32) -> vec4<f32> {
-    let BLEND_DEFAULT = ((MIX_NORMAL << 8u) | COMPOSE_SRC_OVER);
-    // The 0x7fff mask strips bit 15, the MIX_CLIP marker, so both the plain
-    // normal+src_over blend and the pure clip case take this fast path.
-    if (mode & 0x7fffu) == BLEND_DEFAULT {
-        return backdrop * (1.0 - src.a) + src;
-    }
-    // Un-premultiply colors for blending.
-    var cs = unpremultiply(src);
-    let cb = unpremultiply(backdrop);
-    let mix_mode = mode >> 8u;
-    let mixed = blend_mix(cb, cs, mix_mode);
-    cs = mix(cs, mixed, backdrop.a);
-    let compose_mode = mode & 0xffu;
-    if compose_mode == COMPOSE_SRC_OVER {
-        let co = mix(backdrop.rgb, cs, src.a);
-        return vec4(co, src.a + backdrop.a * (1.0 - src.a));
-    } else {
-        return blend_compose(cb, cs, backdrop.a, src.a, compose_mode);
+            return compose_over(backdrop, scaled, blend_overlap(backdrop, scaled, mix_mode));
+        }
     }
 }

--- a/src/ImageSharp.Drawing.WebGPU/Shaders/WgslSource/Shared/drawtag.wgsl
+++ b/src/ImageSharp.Drawing.WebGPU/Shaders/WgslSource/Shared/drawtag.wgsl
@@ -61,7 +61,7 @@ const DRAW_FLAGS_BLEND_ALPHA_MASK = 0x3fffc000u;
 // clip so fine inverts the mask. Declared here because every consumer imports this module.
 const CLIP_DIFFERENCE_MASK_BIT = 0x80000000u;
 // Marks an ISOLATED group (a layer). Isolated groups seed with transparent content and
-// composite back with blend_mix_compose, matching the CPU backend's clean layer targets.
+// composite back with compose_source, matching the CPU backend's clean layer targets.
 // Non-isolated groups (canvas clips) seed with a copy of the current tile content and pop
 // with a coverage lerp, matching the CPU backend's per-draw clip masking so composition
 // modes such as Src behave identically whether or not a tile goes through the clip group.

--- a/src/ImageSharp.Drawing.WebGPU/Shaders/WgslSource/fine.wgsl
+++ b/src/ImageSharp.Drawing.WebGPU/Shaders/WgslSource/fine.wgsl
@@ -54,7 +54,7 @@ var<storage> info: array<u32>;
 
 // Scratch for clip/blend stack entries deeper than BLEND_STACK_SPLIT.
 @group(0) @binding(4)
-var<storage, read_write> blend_spill: array<vec2<u32>>;
+var<storage, read_write> blend_spill: array<vec4<u32>>;
 
 // Final render target; its declaration and encoding are specialized by the host.
 @group(0) @binding(5)
@@ -248,16 +248,6 @@ fn read_draw_blend_mode(draw_flags: u32) -> u32 {
     return (draw_flags & DRAW_FLAGS_BLEND_MODE_MASK) >> DRAW_FLAGS_BLEND_MODE_SHIFT;
 }
 
-// Extracts the mix (blending) mode from a draw-flags word.
-fn read_draw_mix_mode(draw_flags: u32) -> u32 {
-    return read_draw_blend_mode(draw_flags) >> 8u;
-}
-
-// Extracts the Porter-Duff compose mode from a draw-flags word.
-fn read_draw_compose_mode(draw_flags: u32) -> u32 {
-    return read_draw_blend_mode(draw_flags) & 0xffu;
-}
-
 // Extracts the layer alpha from a draw-flags word, stored as a 16-bit
 // normalized value.
 fn read_draw_blend_alpha(draw_flags: u32) -> f32 {
@@ -265,182 +255,29 @@ fn read_draw_blend_alpha(draw_flags: u32) -> f32 {
     return f32(packed) / 65535.0;
 }
 
-// True when the flags encode plain source-over at full layer alpha, which
-// allows compose_draw to take the fast path.
-fn is_default_draw_blend(draw_flags: u32) -> bool {
-    return read_draw_blend_mode(draw_flags) == ((MIX_NORMAL << 8u) | COMPOSE_SRC_OVER)
-        && (draw_flags & DRAW_FLAGS_BLEND_ALPHA_MASK) == DRAW_FLAGS_BLEND_ALPHA_MASK;
-}
-
-// Recolor's inner blend uses a distance-derived alpha rather than the layer alpha in
-// draw_flags. Keep that distinct from compose_draw so ordinary draws retain their exact path.
+// Recolor's inner blend uses a distance-derived alpha rather than the layer
+// alpha in draw_flags. That alpha plays the same role as the CPU blender's
+// amount operand, so it routes through the shared CPU-ported compositor.
 fn compose_recolor_inner(backdrop: vec4<f32>, source: vec4<f32>, blend_alpha: f32, draw_flags: u32) -> vec4<f32> {
-    let effective_alpha = source.a * blend_alpha;
-
-    if read_draw_blend_mode(draw_flags) == ((MIX_NORMAL << 8u) | COMPOSE_SRC_OVER) {
-        return backdrop * (1.0 - effective_alpha) + (source * blend_alpha);
-    }
-
-    let cb = unpremultiply(backdrop);
-    let cs = unpremultiply(source);
-    let ab = backdrop.a;
-    let as_ = effective_alpha;
-    let mix_mode = read_draw_mix_mode(draw_flags);
-    let compose_mode = read_draw_compose_mode(draw_flags);
-    let shared_alpha = as_ * ab;
-
-    switch compose_mode {
-        case COMPOSE_CLEAR: {
-            return vec4(0.0);
-        }
-        case COMPOSE_COPY: {
-            return vec4(cs * as_, as_);
-        }
-        case COMPOSE_DEST: {
-            return backdrop;
-        }
-        case COMPOSE_SRC_OVER: {
-            let blend = blend_mix(cb, cs, mix_mode);
-            let dst_weight = ab - shared_alpha;
-            let src_weight = as_ - shared_alpha;
-            let alpha = dst_weight + as_;
-            let premul = (cb * dst_weight) + (cs * src_weight) + (blend * shared_alpha);
-            return vec4(premul, alpha);
-        }
-        case COMPOSE_DEST_OVER: {
-            let blend = blend_mix(cs, cb, mix_mode);
-            let dst_weight = as_ - shared_alpha;
-            let src_weight = ab - shared_alpha;
-            let alpha = dst_weight + ab;
-            let premul = (cs * dst_weight) + (cb * src_weight) + (blend * shared_alpha);
-            return vec4(premul, alpha);
-        }
-        case COMPOSE_SRC_IN: {
-            return vec4(cs * shared_alpha, shared_alpha);
-        }
-        case COMPOSE_DEST_IN: {
-            return vec4(cb * shared_alpha, shared_alpha);
-        }
-        case COMPOSE_SRC_OUT: {
-            let alpha = as_ * (1.0 - ab);
-            return vec4(cs * alpha, alpha);
-        }
-        case COMPOSE_DEST_OUT: {
-            let alpha = ab * (1.0 - as_);
-            return vec4(cb * alpha, alpha);
-        }
-        case COMPOSE_SRC_ATOP: {
-            let blend = blend_mix(cb, cs, mix_mode);
-            let dst_weight = ab - shared_alpha;
-            let premul = (cb * dst_weight) + (blend * shared_alpha);
-            return vec4(premul, ab);
-        }
-        case COMPOSE_DEST_ATOP: {
-            let blend = blend_mix(cs, cb, mix_mode);
-            let dst_weight = as_ - shared_alpha;
-            let premul = (cs * dst_weight) + (blend * shared_alpha);
-            return vec4(premul, as_);
-        }
-        case COMPOSE_XOR: {
-            let src_weight = as_ * (1.0 - ab);
-            let dst_weight = ab * (1.0 - as_);
-            return vec4((cs * src_weight) + (cb * dst_weight), src_weight + dst_weight);
-        }
-        default: {
-            return blend_mix_compose(backdrop, source * blend_alpha, read_draw_blend_mode(draw_flags));
-        }
-    }
+    return compose_source(backdrop, source, blend_alpha, read_draw_blend_mode(draw_flags));
 }
 
-// Composites a premultiplied source over a premultiplied backdrop using the
-// mix/compose modes and layer alpha packed in draw_flags. Plain source-over at
-// full alpha takes a fast path. The common Porter-Duff compose operators are
-// expanded inline with the mix result weighted by the shared-alpha region;
-// anything else falls back to blend_mix_compose.
+// Composites an associated source over an associated backdrop using the
+// mix/compose modes and layer alpha packed in draw_flags. The arithmetic is
+// the AssociatedAlphaPorterDuffFunctions port in blend.wgsl, so every draw
+// blends with the same formulas and operand order as the CPU backend.
 fn compose_draw(backdrop: vec4<f32>, source: vec4<f32>, draw_flags: u32) -> vec4<f32> {
-    let effective_alpha = source.a * read_draw_blend_alpha(draw_flags);
-
-    if is_default_draw_blend(draw_flags) {
-        return backdrop * (1.0 - source.a) + source;
-    }
-
-    let cb = unpremultiply(backdrop);
-    let cs = unpremultiply(source);
-    let ab = backdrop.a;
-    let as_ = effective_alpha;
-    let mix_mode = read_draw_mix_mode(draw_flags);
-    let compose_mode = read_draw_compose_mode(draw_flags);
-    let shared_alpha = as_ * ab;
-
-    switch compose_mode {
-        case COMPOSE_CLEAR: {
-            return vec4(0.0);
-        }
-        case COMPOSE_COPY: {
-            return vec4(cs * as_, as_);
-        }
-        case COMPOSE_DEST: {
-            return backdrop;
-        }
-        case COMPOSE_SRC_OVER: {
-            let blend = blend_mix(cb, cs, mix_mode);
-            let dst_weight = ab - shared_alpha;
-            let src_weight = as_ - shared_alpha;
-            let alpha = dst_weight + as_;
-            let premul = (cb * dst_weight) + (cs * src_weight) + (blend * shared_alpha);
-            return vec4(premul, alpha);
-        }
-        case COMPOSE_DEST_OVER: {
-            let blend = blend_mix(cs, cb, mix_mode);
-            let dst_weight = as_ - shared_alpha;
-            let src_weight = ab - shared_alpha;
-            let alpha = dst_weight + ab;
-            let premul = (cs * dst_weight) + (cb * src_weight) + (blend * shared_alpha);
-            return vec4(premul, alpha);
-        }
-        case COMPOSE_SRC_IN: {
-            return vec4(cs * shared_alpha, shared_alpha);
-        }
-        case COMPOSE_DEST_IN: {
-            return vec4(cb * shared_alpha, shared_alpha);
-        }
-        case COMPOSE_SRC_OUT: {
-            let alpha = as_ * (1.0 - ab);
-            return vec4(cs * alpha, alpha);
-        }
-        case COMPOSE_DEST_OUT: {
-            let alpha = ab * (1.0 - as_);
-            return vec4(cb * alpha, alpha);
-        }
-        case COMPOSE_SRC_ATOP: {
-            let blend = blend_mix(cb, cs, mix_mode);
-            let dst_weight = ab - shared_alpha;
-            let premul = (cb * dst_weight) + (blend * shared_alpha);
-            return vec4(premul, ab);
-        }
-        case COMPOSE_DEST_ATOP: {
-            let blend = blend_mix(cs, cb, mix_mode);
-            let dst_weight = as_ - shared_alpha;
-            let premul = (cs * dst_weight) + (blend * shared_alpha);
-            return vec4(premul, as_);
-        }
-        case COMPOSE_XOR: {
-            let src_weight = as_ * (1.0 - ab);
-            let dst_weight = ab * (1.0 - as_);
-            return vec4((cs * src_weight) + (cb * dst_weight), src_weight + dst_weight);
-        }
-        default: {
-            return blend_mix_compose(backdrop, source * read_draw_blend_alpha(draw_flags), read_draw_blend_mode(draw_flags));
-        }
-    }
+    return compose_source(backdrop, source, read_draw_blend_alpha(draw_flags), read_draw_blend_mode(draw_flags));
 }
 
 // Applies compose_draw, then lerps between the backdrop and the composed
 // result by coverage so partial coverage attenuates the whole composite
-// (including destructive compose modes), not just the source alpha.
+// (including destructive compose modes), not just the source alpha. The CPU
+// coverage path (AssociatedAlphaPorterDuffFunctions.BlendWithCoverage) is a
+// fused multiply-add, so fma() is the closest expression of it.
 fn compose_draw_with_coverage(backdrop: vec4<f32>, source: vec4<f32>, coverage: f32, draw_flags: u32) -> vec4<f32> {
     let composed = compose_draw(backdrop, source, draw_flags);
-    return backdrop + ((composed - backdrop) * coverage);
+    return fma(composed - backdrop, vec4(coverage), backdrop);
 }
 
 const PIXEL_FORMAT_RGBA: u32 = 0u;
@@ -1327,7 +1164,7 @@ fn main(
     }
     // Clip saves remain in the fine shader's associated working representation. Two
     // binary16 pairs avoid the severe RGBA8 loss that a nested clip previously introduced.
-    var blend_stack: array<array<vec2<u32>, PIXELS_PER_THREAD>, BLEND_STACK_SPLIT>;
+    var blend_stack: array<array<vec4<u32>, PIXELS_PER_THREAD>, BLEND_STACK_SPLIT>;
     var clip_depth = 0u;
     var area: array<f32, PIXELS_PER_THREAD>;
     var cmd_ix = tile_ix * PTCL_INITIAL_ALLOC;
@@ -1433,7 +1270,7 @@ fn main(
                 let end_clip = read_end_clip(cmd_ix);
                 clip_depth -= 1u;
                 for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
-                    var bg_rgba: vec2<u32>;
+                    var bg_rgba: vec4<u32>;
                     if clip_depth < BLEND_STACK_SPLIT {
                         bg_rgba = blend_stack[clip_depth][i];
                     } else {
@@ -1478,7 +1315,7 @@ fn main(
                         let composed = bg * luminance;
                         rgba[i] = bg + ((composed - bg) * clip_area);
                     } else {
-                        let composed = blend_mix_compose(bg, fg, clip_blend);
+                        let composed = compose_source(bg, fg, 1.0, clip_blend);
                         rgba[i] = bg + ((composed - bg) * clip_area);
                     }
                 }

--- a/src/ImageSharp.Drawing.WebGPU/WebGPUSceneConfig.cs
+++ b/src/ImageSharp.Drawing.WebGPU/WebGPUSceneConfig.cs
@@ -677,7 +677,7 @@ internal readonly struct WebGPUSceneBufferSizes
         WebGPUSceneBufferSize<GpuPathTile> pathTiles,
         WebGPUSceneBufferSize<GpuSegmentCount> segCounts,
         WebGPUSceneBufferSize<GpuPathSegment> segments,
-        WebGPUSceneBufferSize<ulong> blendSpill,
+        WebGPUSceneBufferSize<Vector4> blendSpill,
         WebGPUSceneBufferSize<uint> ptcl)
     {
         this.PathReduced = pathReduced;
@@ -825,7 +825,7 @@ internal readonly struct WebGPUSceneBufferSizes
     /// <summary>
     /// Gets the size of the blend-spill buffer.
     /// </summary>
-    public WebGPUSceneBufferSize<ulong> BlendSpill { get; }
+    public WebGPUSceneBufferSize<Vector4> BlendSpill { get; }
 
     /// <summary>
     /// Gets the size of the PTCL buffer.
@@ -901,7 +901,7 @@ internal readonly struct WebGPUSceneBufferSizes
             WebGPUSceneBufferSize<GpuPathTile>.Create(bumpSizes.PathTiles),
             WebGPUSceneBufferSize<GpuSegmentCount>.Create(bumpSizes.SegCounts),
             WebGPUSceneBufferSize<GpuPathSegment>.Create(bumpSizes.Segments),
-            WebGPUSceneBufferSize<ulong>.Create(bumpSizes.BlendSpill),
+            WebGPUSceneBufferSize<Vector4>.Create(bumpSizes.BlendSpill),
             WebGPUSceneBufferSize<uint>.Create(ptclCount));
     }
 
@@ -953,7 +953,7 @@ internal readonly struct WebGPUSceneBufferSizes
             WebGPUSceneBufferSize<GpuPathTile>.Create(bumpSizes.PathTiles),
             WebGPUSceneBufferSize<GpuSegmentCount>.Create(bumpSizes.SegCounts),
             WebGPUSceneBufferSize<GpuPathSegment>.Create(bumpSizes.Segments),
-            WebGPUSceneBufferSize<ulong>.Create(bumpSizes.BlendSpill),
+            WebGPUSceneBufferSize<Vector4>.Create(bumpSizes.BlendSpill),
             WebGPUSceneBufferSize<uint>.Create(ptclCount));
     }
 

--- a/src/ImageSharp.Drawing.WebGPU/WebGPUSceneEncoder.cs
+++ b/src/ImageSharp.Drawing.WebGPU/WebGPUSceneEncoder.cs
@@ -1640,6 +1640,8 @@ internal static class WebGPUSceneEncoder
             this.PathGradientData = new OwnedStream<uint>(allocator, plan.PathGradientDataWordCapacity);
             this.Images = [];
             this.Recolors = [];
+            this.SolidColors = [];
+            this.GradientRamps = [];
             this.FillCount = 0;
             this.PathCount = 0;
             this.LineCount = 0;
@@ -1738,6 +1740,16 @@ internal static class WebGPUSceneEncoder
         /// Gets or sets the deferred RecolorBrush payload descriptors specialized for the render target pixel type.
         /// </summary>
         public List<GpuRecolorDescriptor> Recolors;
+
+        /// <summary>
+        /// Gets or sets the deferred solid color descriptors specialized for the render target pixel type.
+        /// </summary>
+        public List<GpuSolidColorDescriptor> SolidColors;
+
+        /// <summary>
+        /// Gets or sets the deferred gradient ramp descriptors specialized for the render target pixel type.
+        /// </summary>
+        public List<GpuGradientRampDescriptor> GradientRamps;
 
         /// <summary>
         /// Gets the number of emitted fill records.
@@ -2645,6 +2657,8 @@ internal static class WebGPUSceneEncoder
                     ref this.PathGradientData,
                     this.Images,
                     this.Recolors,
+                    this.SolidColors,
+                    this.GradientRamps,
                     ref gradientRowCount);
             }
 
@@ -2763,6 +2777,8 @@ internal static class WebGPUSceneEncoder
                 ref this.PathGradientData,
                 this.Images,
                 this.Recolors,
+                this.SolidColors,
+                this.GradientRamps,
                 ref gradientRowCount);
             this.GradientRowCount = gradientRowCount;
         }
@@ -2882,6 +2898,8 @@ internal static class WebGPUSceneEncoder
                 ref this.PathGradientData,
                 this.Images,
                 this.Recolors,
+                this.SolidColors,
+                this.GradientRamps,
                 ref gradientRowCount);
             this.GradientRowCount = gradientRowCount;
         }
@@ -3003,6 +3021,8 @@ internal static class WebGPUSceneEncoder
                 ref this.PathGradientData,
                 this.Images,
                 this.Recolors,
+                this.SolidColors,
+                this.GradientRamps,
                 ref gradientRowCount);
             this.GradientRowCount = gradientRowCount;
         }
@@ -3529,6 +3549,8 @@ internal static class WebGPUSceneEncoder
         /// <param name="pathGradientDataOwner">The detached path-gradient storage, or <see langword="null"/> when no path gradients were emitted.</param>
         /// <param name="images">The deferred image descriptors recorded by the partition.</param>
         /// <param name="recolors">The deferred recolor descriptors recorded by the partition.</param>
+        /// <param name="solidColors">The deferred solid color descriptors recorded by the partition.</param>
+        /// <param name="gradientRamps">The deferred gradient ramp descriptors recorded by the partition.</param>
         /// <param name="fillCount">The number of emitted fill records.</param>
         /// <param name="visibleFillCount">The number of visible fills accepted by staged-scene validation.</param>
         /// <param name="pathCount">The number of emitted paths.</param>
@@ -3559,6 +3581,8 @@ internal static class WebGPUSceneEncoder
             IMemoryOwner<uint>? pathGradientDataOwner,
             List<GpuImageDescriptor> images,
             List<GpuRecolorDescriptor> recolors,
+            List<GpuSolidColorDescriptor> solidColors,
+            List<GpuGradientRampDescriptor> gradientRamps,
             int fillCount,
             int visibleFillCount,
             int pathCount,
@@ -3590,6 +3614,8 @@ internal static class WebGPUSceneEncoder
             this.profileStorage = profileStorage;
             this.Images = images;
             this.Recolors = recolors;
+            this.SolidColors = solidColors;
+            this.GradientRamps = gradientRamps;
             this.FillCount = fillCount;
             this.VisibleFillCount = visibleFillCount;
             this.PathCount = pathCount;
@@ -3671,6 +3697,16 @@ internal static class WebGPUSceneEncoder
         /// Gets the deferred recolor descriptors recorded by this partition.
         /// </summary>
         public List<GpuRecolorDescriptor> Recolors { get; }
+
+        /// <summary>
+        /// Gets the deferred solid color descriptors recorded by this partition.
+        /// </summary>
+        public List<GpuSolidColorDescriptor> SolidColors { get; }
+
+        /// <summary>
+        /// Gets the deferred gradient ramp descriptors recorded by this partition.
+        /// </summary>
+        public List<GpuGradientRampDescriptor> GradientRamps { get; }
 
         /// <summary>
         /// Gets the number of emitted fill records.
@@ -3807,6 +3843,8 @@ internal static class WebGPUSceneEncoder
                 pathGradientDataOwner,
                 encoding.Images,
                 encoding.Recolors,
+                encoding.SolidColors,
+                encoding.GradientRamps,
                 encoding.FillCount,
                 encoding.VisibleFillCount,
                 encoding.PathCount,
@@ -3958,6 +3996,8 @@ internal static class WebGPUSceneEncoder
                     pathGradientDataWordCount,
                     encoding.Images,
                     encoding.Recolors,
+                    encoding.SolidColors,
+                    encoding.GradientRamps,
                     encoding.GradientRowCount,
                     layout,
                     encoding.FillCount,
@@ -4352,6 +4392,8 @@ internal static class WebGPUSceneEncoder
             int pathGradientDataWordCount = 0;
             int imageCount = 0;
             int recolorCount = 0;
+            int solidColorCount = 0;
+            int gradientRampCount = 0;
             int gradientRowCount = 0;
             int fillCount = 0;
             int pathCount = 0;
@@ -4375,6 +4417,8 @@ internal static class WebGPUSceneEncoder
                 pathGradientDataWordCount += partition.PathGradientDataWordCount;
                 imageCount += partition.Images.Count;
                 recolorCount += partition.Recolors.Count;
+                solidColorCount += partition.SolidColors.Count;
+                gradientRampCount += partition.GradientRamps.Count;
                 gradientRowCount += partition.GradientRowCount;
                 fillCount += partition.FillCount;
                 pathCount += partition.PathCount;
@@ -4439,6 +4483,8 @@ internal static class WebGPUSceneEncoder
                 Span<byte> sceneBytes = MemoryMarshal.Cast<uint, byte>(sceneWords);
                 List<GpuImageDescriptor> images = new(imageCount);
                 List<GpuRecolorDescriptor> recolors = new(recolorCount);
+                List<GpuSolidColorDescriptor> solidColors = new(solidColorCount);
+                List<GpuGradientRampDescriptor> gradientRamps = new(gradientRampCount);
                 int pathTagOffset = 0;
                 int pathDataOffset = 0;
                 int drawTagOffset = 0;
@@ -4482,6 +4528,24 @@ internal static class WebGPUSceneEncoder
                             recolor.TargetColor,
                             recolor.Threshold,
                             pathGradientDataOffset + recolor.BrushDataWordOffset));
+                    }
+
+                    for (int solidColorIndex = 0; solidColorIndex < partition.SolidColors.Count; solidColorIndex++)
+                    {
+                        GpuSolidColorDescriptor solidColor = partition.SolidColors[solidColorIndex];
+
+                        solidColors.Add(new GpuSolidColorDescriptor(
+                            solidColor.Color,
+                            drawDataOffset + solidColor.DrawDataWordOffset));
+                    }
+
+                    for (int gradientRampIndex = 0; gradientRampIndex < partition.GradientRamps.Count; gradientRampIndex++)
+                    {
+                        GpuGradientRampDescriptor gradientRamp = partition.GradientRamps[gradientRampIndex];
+
+                        gradientRamps.Add(new GpuGradientRampDescriptor(
+                            gradientRamp.ColorStops,
+                            gradientRowOffset + gradientRamp.RowIndex));
                     }
 
                     drawDataOffset += partition.DrawDataWordCount;
@@ -4531,6 +4595,8 @@ internal static class WebGPUSceneEncoder
                     pathGradientDataWordCount,
                     images,
                     recolors,
+                    solidColors,
+                    gradientRamps,
                     gradientRowCount,
                     layout,
                     fillCount,
@@ -6617,8 +6683,18 @@ internal static class WebGPUSceneEncoder
     /// </summary>
     /// <param name="solidBrush">The solid brush to encode.</param>
     /// <param name="drawData">The draw-data stream.</param>
-    private static void AppendSolidColor(SolidBrush solidBrush, ref OwnedStream<uint> drawData)
-        => AppendColor(solidBrush.Color.ToScaledVector4(PixelAlphaRepresentation.Associated), ref drawData);
+    /// <param name="solidColors">Receives the target-specialized color patch site.</param>
+    private static void AppendSolidColor(
+        SolidBrush solidBrush,
+        ref OwnedStream<uint> drawData,
+        List<GpuSolidColorDescriptor> solidColors)
+    {
+        // The CPU renderer blends a source snapped through TPixel, which is unknown here
+        // because retained scenes bind to any pixel format later. The continuous words keep
+        // the stream layout fixed; the descriptor records where the snapped value is patched.
+        solidColors.Add(new GpuSolidColorDescriptor(solidBrush.Color, drawData.Count));
+        AppendColor(solidBrush.Color.ToScaledVector4(PixelAlphaRepresentation.Associated), ref drawData);
+    }
 
     /// <summary>
     /// Appends the draw-data payload for one encoded draw tag.
@@ -6633,6 +6709,8 @@ internal static class WebGPUSceneEncoder
     /// <param name="pathGradientData">The path-gradient payload stream.</param>
     /// <param name="images">Receives deferred image patch sites.</param>
     /// <param name="recolors">Receives deferred recolor payload patch sites.</param>
+    /// <param name="solidColors">Receives deferred solid color patch sites.</param>
+    /// <param name="gradientRamps">Receives deferred gradient ramp patch sites.</param>
     /// <param name="gradientRowCount">The gradient row counter, advanced when a ramp is emitted.</param>
     private static void AppendDrawData(
         Brush brush,
@@ -6645,6 +6723,8 @@ internal static class WebGPUSceneEncoder
         ref OwnedStream<uint> pathGradientData,
         List<GpuImageDescriptor> images,
         List<GpuRecolorDescriptor> recolors,
+        List<GpuSolidColorDescriptor> solidColors,
+        List<GpuGradientRampDescriptor> gradientRamps,
         ref int gradientRowCount)
     {
         Rectangle localBrushBounds = brush is ImageBrush
@@ -6659,22 +6739,22 @@ internal static class WebGPUSceneEncoder
                 AppendBeginClipData(graphicsOptions, ref drawData);
                 break;
             case GpuSceneDrawTag.FillColor:
-                AppendSolidColor((SolidBrush)brush, ref drawData);
+                AppendSolidColor((SolidBrush)brush, ref drawData, solidColors);
                 break;
             case GpuSceneDrawTag.FillRecolor:
                 AppendRecolorData((RecolorBrush)brush, ref drawData, ref pathGradientData, recolors);
                 break;
             case GpuSceneDrawTag.FillLinGradient:
-                AppendLinearGradientData((LinearGradientBrush)brush, ref drawData, ref gradientPixels, ref gradientRowCount);
+                AppendLinearGradientData((LinearGradientBrush)brush, ref drawData, ref gradientPixels, gradientRamps, ref gradientRowCount);
                 break;
             case GpuSceneDrawTag.FillRadGradient:
-                AppendRadialGradientData((RadialGradientBrush)brush, ref drawData, ref gradientPixels, ref gradientRowCount);
+                AppendRadialGradientData((RadialGradientBrush)brush, ref drawData, ref gradientPixels, gradientRamps, ref gradientRowCount);
                 break;
             case GpuSceneDrawTag.FillEllipticGradient:
-                AppendEllipticGradientData((EllipticGradientBrush)brush, ref drawData, ref gradientPixels, ref gradientRowCount);
+                AppendEllipticGradientData((EllipticGradientBrush)brush, ref drawData, ref gradientPixels, gradientRamps, ref gradientRowCount);
                 break;
             case GpuSceneDrawTag.FillSweepGradient:
-                AppendSweepGradientData((SweepGradientBrush)brush, ref drawData, ref gradientPixels, ref gradientRowCount);
+                AppendSweepGradientData((SweepGradientBrush)brush, ref drawData, ref gradientPixels, gradientRamps, ref gradientRowCount);
                 break;
             case GpuSceneDrawTag.FillPathGradient:
                 AppendPathGradientData((PathGradientBrush)brush, rootTargetBounds, ref drawData, ref pathGradientData);
@@ -6749,6 +6829,15 @@ internal static class WebGPUSceneEncoder
             PixelColorBlendingMode.Lighten => 5U,
             PixelColorBlendingMode.Overlay => 3U,
             PixelColorBlendingMode.HardLight => 8U,
+            PixelColorBlendingMode.ColorDodge => 6U,
+            PixelColorBlendingMode.ColorBurn => 7U,
+            PixelColorBlendingMode.SoftLight => 9U,
+            PixelColorBlendingMode.Difference => 10U,
+            PixelColorBlendingMode.Exclusion => 11U,
+            PixelColorBlendingMode.Hue => 12U,
+            PixelColorBlendingMode.Saturation => 13U,
+            PixelColorBlendingMode.Color => 14U,
+            PixelColorBlendingMode.Luminosity => 15U,
             _ => throw new UnreachableException($"Unsupported color blending mode '{mode}'.")
         };
 
@@ -6773,6 +6862,7 @@ internal static class WebGPUSceneEncoder
             PixelAlphaCompositionMode.DestOut => 8U,
             PixelAlphaCompositionMode.Clear => 0U,
             PixelAlphaCompositionMode.Xor => 11U,
+            PixelAlphaCompositionMode.Plus => 12U,
             _ => throw new UnreachableException($"Unsupported alpha composition mode '{mode}'.")
         };
 
@@ -6843,15 +6933,18 @@ internal static class WebGPUSceneEncoder
     /// <param name="brush">The linear gradient brush.</param>
     /// <param name="drawData">The draw-data stream.</param>
     /// <param name="gradientPixels">The gradient-pixel stream.</param>
+    /// <param name="gradientRamps">Receives the target-specialized ramp patch site.</param>
     /// <param name="gradientRowCount">The gradient row counter, advanced by one.</param>
     private static void AppendLinearGradientData(
         LinearGradientBrush brush,
         ref OwnedStream<uint> drawData,
         ref OwnedStream<uint> gradientPixels,
+        List<GpuGradientRampDescriptor> gradientRamps,
         ref int gradientRowCount)
     {
         uint indexMode = ((uint)gradientRowCount << 2) | MapExtendMode(brush.RepetitionMode);
-        AppendGradientRamp(brush.ColorStops, ref gradientPixels);
+        AppendGradientRamp(ref gradientPixels);
+        gradientRamps.Add(new GpuGradientRampDescriptor(brush.ColorStops.ToArray(), gradientRowCount));
         gradientRowCount++;
 
         drawData.Add(indexMode);
@@ -6867,15 +6960,18 @@ internal static class WebGPUSceneEncoder
     /// <param name="brush">The radial gradient brush.</param>
     /// <param name="drawData">The draw-data stream.</param>
     /// <param name="gradientPixels">The gradient-pixel stream.</param>
+    /// <param name="gradientRamps">Receives the target-specialized ramp patch site.</param>
     /// <param name="gradientRowCount">The gradient row counter, advanced by one.</param>
     private static void AppendRadialGradientData(
         RadialGradientBrush brush,
         ref OwnedStream<uint> drawData,
         ref OwnedStream<uint> gradientPixels,
+        List<GpuGradientRampDescriptor> gradientRamps,
         ref int gradientRowCount)
     {
         uint indexMode = ((uint)gradientRowCount << 2) | MapExtendMode(brush.RepetitionMode);
-        AppendGradientRamp(brush.ColorStops, ref gradientPixels);
+        AppendGradientRamp(ref gradientPixels);
+        gradientRamps.Add(new GpuGradientRampDescriptor(brush.ColorStops.ToArray(), gradientRowCount));
         gradientRowCount++;
 
         PointF center0;
@@ -6913,15 +7009,18 @@ internal static class WebGPUSceneEncoder
     /// <param name="brush">The elliptic gradient brush.</param>
     /// <param name="drawData">The draw-data stream.</param>
     /// <param name="gradientPixels">The gradient-pixel stream.</param>
+    /// <param name="gradientRamps">Receives the target-specialized ramp patch site.</param>
     /// <param name="gradientRowCount">The gradient row counter, advanced by one.</param>
     private static void AppendEllipticGradientData(
         EllipticGradientBrush brush,
         ref OwnedStream<uint> drawData,
         ref OwnedStream<uint> gradientPixels,
+        List<GpuGradientRampDescriptor> gradientRamps,
         ref int gradientRowCount)
     {
         uint indexMode = ((uint)gradientRowCount << 2) | MapExtendMode(brush.RepetitionMode);
-        AppendGradientRamp(brush.ColorStops, ref gradientPixels);
+        AppendGradientRamp(ref gradientPixels);
+        gradientRamps.Add(new GpuGradientRampDescriptor(brush.ColorStops.ToArray(), gradientRowCount));
         gradientRowCount++;
 
         // Brushes reach the encoder after batcher normalization, so gradient payload points are
@@ -6948,15 +7047,18 @@ internal static class WebGPUSceneEncoder
     /// <param name="brush">The sweep gradient brush.</param>
     /// <param name="drawData">The draw-data stream.</param>
     /// <param name="gradientPixels">The gradient-pixel stream.</param>
+    /// <param name="gradientRamps">Receives the target-specialized ramp patch site.</param>
     /// <param name="gradientRowCount">The gradient row counter, advanced by one.</param>
     private static void AppendSweepGradientData(
         SweepGradientBrush brush,
         ref OwnedStream<uint> drawData,
         ref OwnedStream<uint> gradientPixels,
+        List<GpuGradientRampDescriptor> gradientRamps,
         ref int gradientRowCount)
     {
         uint indexMode = ((uint)gradientRowCount << 2) | MapExtendMode(brush.RepetitionMode);
-        AppendGradientRamp(brush.ColorStops, ref gradientPixels);
+        AppendGradientRamp(ref gradientPixels);
+        gradientRamps.Add(new GpuGradientRampDescriptor(brush.ColorStops.ToArray(), gradientRowCount));
         gradientRowCount++;
 
         float sweepDegrees = brush.EndAngleDegrees - brush.StartAngleDegrees;
@@ -7044,17 +7146,20 @@ internal static class WebGPUSceneEncoder
     }
 
     /// <summary>
-    /// Appends one packed gradient ramp row sampled across the fixed gradient width.
+    /// Reserves one zeroed gradient ramp row across the fixed gradient width.
     /// </summary>
-    /// <param name="colorStops">The gradient color stops, ordered by ratio.</param>
     /// <param name="gradientPixels">The gradient-pixel stream.</param>
-    private static void AppendGradientRamp(ReadOnlySpan<ColorStop> colorStops, ref OwnedStream<uint> gradientPixels)
+    /// <remarks>
+    /// The texels are written by <see cref="WebGPUEncodedScene.SpecializeBrushColors{TPixel}"/>
+    /// when a flush binds the scene to its pixel format: every ramp sample must snap through
+    /// the target pixel type, so values baked here would be discarded. The row advances zeroed
+    /// to keep the stream layout fixed.
+    /// </remarks>
+    private static void AppendGradientRamp(ref OwnedStream<uint> gradientPixels)
     {
-        for (int x = 0; x < GradientWidth; x++)
-        {
-            float t = x / (float)(GradientWidth - 1);
-            AppendColor(EvaluateGradientColor(colorStops, t), ref gradientPixels);
-        }
+        Span<uint> row = gradientPixels.GetAppendSpan(GradientRowWordCount);
+        row.Clear();
+        gradientPixels.Advance(GradientRowWordCount);
     }
 
     /// <summary>
@@ -7063,7 +7168,7 @@ internal static class WebGPUSceneEncoder
     /// <param name="colorStops">The gradient color stops, ordered by ratio.</param>
     /// <param name="t">The normalized sample position in the range [0, 1].</param>
     /// <returns>The associated floating-point sample.</returns>
-    private static Vector4 EvaluateGradientColor(ReadOnlySpan<ColorStop> colorStops, float t)
+    public static Vector4 EvaluateGradientColor(ReadOnlySpan<ColorStop> colorStops, float t)
     {
         // Walk the stop list once to find the enclosing interval, then interpolate within it.
         ColorStop from = colorStops[0];
@@ -7112,7 +7217,7 @@ internal static class WebGPUSceneEncoder
     /// <param name="y">The high component.</param>
     /// <returns>The packed pair.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static uint PackHalf2(float x, float y)
+    public static uint PackHalf2(float x, float y)
         => BitConverter.HalfToUInt16Bits((Half)x) | ((uint)BitConverter.HalfToUInt16Bits((Half)y) << 16);
 
     /// <summary>
@@ -7187,6 +7292,8 @@ internal sealed class WebGPUEncodedScene : IDisposable
         0,
         [],
         [],
+        [],
+        [],
         0,
         default,
         0,
@@ -7213,8 +7320,16 @@ internal sealed class WebGPUEncodedScene : IDisposable
     private readonly IMemoryOwner<uint>? pathGradientDataOwner;
     private readonly List<GpuImageDescriptor> images;
     private readonly List<GpuRecolorDescriptor> recolors;
+    private readonly List<GpuSolidColorDescriptor> solidColors;
+    private readonly List<GpuGradientRampDescriptor> gradientRamps;
     private readonly WebGPUSceneOperation[] operations;
     private bool disposed;
+
+    /// <summary>
+    /// The pixel type the solid color words and gradient ramp texels are specialized for, or
+    /// <see langword="null"/> while they hold the encoder's continuous values.
+    /// </summary>
+    private Type? specializedPixelType;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WebGPUEncodedScene"/> class.
@@ -7228,6 +7343,8 @@ internal sealed class WebGPUEncodedScene : IDisposable
     /// <param name="pathGradientDataWordCount">The number of path-gradient data words.</param>
     /// <param name="images">The image descriptors referenced by draw data.</param>
     /// <param name="recolors">The recolor descriptors referenced by auxiliary brush data.</param>
+    /// <param name="solidColors">The solid color descriptors referenced by draw data.</param>
+    /// <param name="gradientRamps">The gradient ramp descriptors referenced by the ramp texture rows.</param>
     /// <param name="gradientRowCount">The number of gradient texture rows.</param>
     /// <param name="layout">The packed GPU scene layout.</param>
     /// <param name="fillCount">The number of fill draw records.</param>
@@ -7258,6 +7375,8 @@ internal sealed class WebGPUEncodedScene : IDisposable
         int pathGradientDataWordCount,
         List<GpuImageDescriptor> images,
         List<GpuRecolorDescriptor> recolors,
+        List<GpuSolidColorDescriptor> solidColors,
+        List<GpuGradientRampDescriptor> gradientRamps,
         int gradientRowCount,
         GpuSceneLayout layout,
         int fillCount,
@@ -7287,6 +7406,8 @@ internal sealed class WebGPUEncodedScene : IDisposable
         this.PathGradientDataWordCount = pathGradientDataWordCount;
         this.images = images;
         this.recolors = recolors;
+        this.solidColors = solidColors;
+        this.gradientRamps = gradientRamps;
         this.operations = operations;
         this.SceneWordCount = sceneWordCount;
         this.GradientRowCount = gradientRowCount;
@@ -7441,6 +7562,16 @@ internal sealed class WebGPUEncodedScene : IDisposable
     /// Gets the deferred recolor descriptors that must be specialized for the target pixel type.
     /// </summary>
     public IReadOnlyList<GpuRecolorDescriptor> Recolors => this.recolors;
+
+    /// <summary>
+    /// Gets the deferred solid color descriptors that must be specialized for the target pixel type.
+    /// </summary>
+    public IReadOnlyList<GpuSolidColorDescriptor> SolidColors => this.solidColors;
+
+    /// <summary>
+    /// Gets the deferred gradient ramp descriptors that must be specialized for the target pixel type.
+    /// </summary>
+    public IReadOnlyList<GpuGradientRampDescriptor> GradientRamps => this.gradientRamps;
 
     /// <summary>
     /// Gets the ordered retained operations for a scene containing Apply.
@@ -7645,6 +7776,131 @@ internal sealed class WebGPUEncodedScene : IDisposable
     }
 
     /// <summary>
+    /// Rewrites the retained solid color words and gradient ramp texels with values snapped
+    /// through <typeparamref name="TPixel"/>, so the shader blends the same sources the CPU
+    /// renderer blends.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The pixel type is unknown until a flush binds the scene to a target, so the snap cannot
+    /// happen at encode time. Mutating the retained streams lets the snapped values ride the
+    /// scene upload and the ramp texture write that happen anyway; patching them GPU-side would
+    /// cost one queue call per solid draw per flush. <see cref="SetSceneWord"/> skips identical
+    /// rewrites, so repeated flushes at one pixel type upload nothing new, and a pixel type
+    /// change re-uploads only the words that differ.
+    /// </para>
+    /// <para>
+    /// Precision contract: the wire format is associated binary16, so straight-alpha snapped
+    /// components multiply by alpha and the product rounds. Opaque values are exempt because
+    /// multiplying by one changes nothing and every 8-bit value is exactly representable, so
+    /// they blend bit-identically to the CPU. Translucent values carry the product rounding
+    /// into the blend, and with output rounding stacked on top a rare pixel can land two 8-bit
+    /// steps from the CPU result. Removing that requires straight transport plus an in-shader
+    /// premultiply, which for ramps also changes how the sampler interpolates between texels.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TPixel">The pixel format of the target.</typeparam>
+    public void SpecializeBrushColors<TPixel>()
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        if (this.specializedPixelType == typeof(TPixel))
+        {
+            return;
+        }
+
+        PixelAlphaRepresentation alphaRepresentation = TPixel.GetPixelTypeInfo().AlphaRepresentation;
+        this.SpecializeSolidColors<TPixel>(alphaRepresentation);
+        this.SpecializeGradientRamps<TPixel>(alphaRepresentation);
+        this.specializedPixelType = typeof(TPixel);
+    }
+
+    /// <summary>
+    /// Rewrites each solid fill's packed draw-data words with the color snapped through
+    /// <typeparamref name="TPixel"/>, mirroring the conversion <c>SolidBrush</c> performs when
+    /// it creates its CPU renderer.
+    /// </summary>
+    /// <typeparam name="TPixel">The pixel format of the target.</typeparam>
+    /// <param name="alphaRepresentation">The alpha representation of <typeparamref name="TPixel"/>.</param>
+    private void SpecializeSolidColors<TPixel>(PixelAlphaRepresentation alphaRepresentation)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        for (int i = 0; i < this.solidColors.Count; i++)
+        {
+            GpuSolidColorDescriptor descriptor = this.solidColors[i];
+            Vector4 color = descriptor.Color.ToPixel<TPixel>().ToScaledVector4();
+            if (alphaRepresentation != PixelAlphaRepresentation.Associated)
+            {
+                // Associating rounds the product into binary16; see the precision contract on
+                // SpecializeBrushColors.
+                float alpha = color.W;
+                color *= alpha;
+                color.W = alpha;
+            }
+
+            int wordIndex = checked((int)this.Layout.DrawDataBase + descriptor.DrawDataWordOffset);
+            this.SetSceneWord(wordIndex, WebGPUSceneEncoder.PackHalf2(color.X, color.Y));
+            this.SetSceneWord(wordIndex + 1, WebGPUSceneEncoder.PackHalf2(color.Z, color.W));
+        }
+    }
+
+    /// <summary>
+    /// Rewrites each recorded gradient ramp row with texels snapped through
+    /// <typeparamref name="TPixel"/>, mirroring the per-pixel conversion the CPU gradient
+    /// encoders perform before blending.
+    /// </summary>
+    /// <typeparam name="TPixel">The pixel format of the target.</typeparam>
+    /// <param name="alphaRepresentation">The alpha representation of <typeparamref name="TPixel"/>.</param>
+    private void SpecializeGradientRamps<TPixel>(PixelAlphaRepresentation alphaRepresentation)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        if (this.gradientPixelsOwner is null)
+        {
+            return;
+        }
+
+        Span<uint> gradientPixels = this.gradientPixelsOwner.Memory.Span;
+        for (int i = 0; i < this.gradientRamps.Count; i++)
+        {
+            GpuGradientRampDescriptor descriptor = this.gradientRamps[i];
+            int rowBase = descriptor.RowIndex * WebGPUSceneEncoder.GradientRowWordCount;
+            for (int x = 0; x < WebGPUSceneEncoder.GradientWidth; x++)
+            {
+                float t = x / (float)(WebGPUSceneEncoder.GradientWidth - 1);
+                Vector4 color = WebGPUSceneEncoder.EvaluateGradientColor(descriptor.ColorStops, t);
+                if (alphaRepresentation == PixelAlphaRepresentation.Associated)
+                {
+                    color = TPixel.FromScaledVector4(color).ToScaledVector4();
+                }
+                else
+                {
+                    // The CPU's straight-alpha encoder undoes the interpolation-time
+                    // premultiplication before converting to TPixel, so the same division
+                    // precedes the snap. Re-associating rounds the product into binary16;
+                    // see the precision contract on SpecializeBrushColors.
+                    float alpha = color.W;
+                    if (alpha > 0)
+                    {
+                        color /= alpha;
+                        color.W = alpha;
+                    }
+                    else
+                    {
+                        color = Vector4.Zero;
+                    }
+
+                    color = TPixel.FromScaledVector4(color).ToScaledVector4();
+                    float snappedAlpha = color.W;
+                    color *= snappedAlpha;
+                    color.W = snappedAlpha;
+                }
+
+                gradientPixels[rowBase + (x * 2)] = WebGPUSceneEncoder.PackHalf2(color.X, color.Y);
+                gradientPixels[rowBase + (x * 2) + 1] = WebGPUSceneEncoder.PackHalf2(color.Z, color.W);
+            }
+        }
+    }
+
+    /// <summary>
     /// Releases the owned scene, gradient, and path-gradient buffers.
     /// </summary>
     public void Dispose()
@@ -7828,6 +8084,61 @@ internal readonly struct GpuRecolorDescriptor
     /// Gets the auxiliary brush-data word offset to patch for the render target.
     /// </summary>
     public int BrushDataWordOffset { get; }
+}
+
+/// <summary>
+/// Describes one solid brush color whose packed draw-data words must be converted for the
+/// render target pixel type.
+/// </summary>
+internal readonly struct GpuSolidColorDescriptor
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GpuSolidColorDescriptor"/> struct.
+    /// </summary>
+    /// <param name="color">The full-precision brush color.</param>
+    /// <param name="drawDataWordOffset">The draw-data word offset of the packed color to patch.</param>
+    public GpuSolidColorDescriptor(Color color, int drawDataWordOffset)
+    {
+        this.Color = color;
+        this.DrawDataWordOffset = drawDataWordOffset;
+    }
+
+    /// <summary>
+    /// Gets the full-precision brush color.
+    /// </summary>
+    public Color Color { get; }
+
+    /// <summary>
+    /// Gets the draw-data word offset of the packed color to patch for the render target.
+    /// </summary>
+    public int DrawDataWordOffset { get; }
+}
+
+/// <summary>
+/// Describes one gradient ramp row whose texels must be converted for the render target pixel type.
+/// </summary>
+internal readonly struct GpuGradientRampDescriptor
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GpuGradientRampDescriptor"/> struct.
+    /// </summary>
+    /// <param name="colorStops">The gradient color stops, ordered by ratio.</param>
+    /// <param name="rowIndex">The ramp texture row the gradient occupies.</param>
+    public GpuGradientRampDescriptor(ColorStop[] colorStops, int rowIndex)
+    {
+        this.ColorStops = colorStops;
+        this.RowIndex = rowIndex;
+    }
+
+    /// <summary>
+    /// Gets the gradient color stops, ordered by ratio.
+    /// </summary>
+    public ColorStop[] ColorStops { get; }
+
+    /// <summary>
+    /// Gets the ramp texture row the gradient occupies.
+    /// </summary>
+    public int RowIndex { get; }
 }
 
 /// <summary>

--- a/src/ImageSharp.Drawing.WebGPU/WebGPUSceneResources.cs
+++ b/src/ImageSharp.Drawing.WebGPU/WebGPUSceneResources.cs
@@ -147,6 +147,11 @@ internal static unsafe class WebGPUSceneResources
         resources = default;
         int infoWordCount = range?.InfoWordCount ?? scene.InfoWordCount;
 
+        // The retained solid color words and ramp texels specialize to the target pixel type
+        // before any upload below reads them, so the snapped values ride the ordinary scene
+        // upload and ramp texture write with no per-word GPU patching.
+        scene.SpecializeBrushColors<TPixel>();
+
         // Textures are scene-dependent and not pooled.
         if (!TryCreateGradientTexture(flushContext, scene, out WGPUTextureViewImpl* gradientTextureView, out error))
         {

--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -44,8 +44,8 @@
     <InternalsVisibleTo Include="SixLabors.ImageSharp.Drawing.WebGPU" Key="$(SixLaborsPublicKey)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="3.0.1-alpha.0.16" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.1-alpha.0.20" />
+    <PackageReference Include="SixLabors.Fonts" Version="3.0.1-alpha.0.17" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.1-alpha.0.23" />
     <PackageReference Include="SixLabors.PolygonClipper" Version="1.0.1-alpha.0.6" />
   </ItemGroup>
 

--- a/src/ImageSharp.Drawing/Processing/DrawingCanvas{TPixel}.cs
+++ b/src/ImageSharp.Drawing/Processing/DrawingCanvas{TPixel}.cs
@@ -81,9 +81,16 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
 
     /// <summary>
     /// Reusable sort buffer for <see cref="DrawTextOperations"/>, hosted by the text cache for
-    /// the same reason as <see cref="textOperations"/>.
+    /// the same reason as <see cref="textOperations"/>. Only pass and index pairs are sorted;
+    /// the operations themselves stay in place so the per-draw sort moves eight bytes per
+    /// entry instead of the full operation struct.
     /// </summary>
-    private readonly List<(byte RenderPass, int Sequence, CompositionSceneCommand Command)> textCommandSortBuffer;
+    private readonly List<(byte RenderPass, int Sequence)> textOperationSortBuffer;
+
+    /// <summary>
+    /// Reusable stack pairing the begin and end commands for nested text composite layers.
+    /// </summary>
+    private readonly List<DrawingCanvasLayer> textCompositeLayerStack;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DrawingCanvas{TPixel}"/> class.
@@ -297,7 +304,8 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
         this.batcher = batcher;
         this.textCache = textCache;
         this.textOperations = textCache.OperationScratch;
-        this.textCommandSortBuffer = textCache.CommandSortScratch;
+        this.textOperationSortBuffer = textCache.OperationSortScratch;
+        this.textCompositeLayerStack = textCache.CompositeLayerScratch;
         this.ownsBatcher = ownsBatcher;
         this.ownsTextCache = ownsTextCache;
         this.pendingImageResources = pendingImageResources;
@@ -1660,11 +1668,13 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
                         operation.RenderLocation.X - fillOperation.RenderLocation.X,
                         operation.RenderLocation.Y - fillOperation.RenderLocation.Y)
                         + operation.SubPixelOffset - fillOperation.SubPixelOffset;
+
                     fillEntries[fillCount++] = new DrawingTextCache.RunPathCacheEntry(
-                        operation.Path,
+                        operation.Path!,
                         fillRelativeLocation,
                         operation.GlyphKey,
                         operation.HasGlyphKey);
+
                     break;
 
                 case DrawingOperationKind.Draw:
@@ -1684,12 +1694,19 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
                         operation.RenderLocation.X - drawOperation.RenderLocation.X,
                         operation.RenderLocation.Y - drawOperation.RenderLocation.Y)
                         + operation.SubPixelOffset - drawOperation.SubPixelOffset;
+
                     drawEntries[drawCount++] = new DrawingTextCache.RunPathCacheEntry(
-                        operation.Path,
+                        operation.Path!,
                         drawRelativeLocation,
                         operation.GlyphKey,
                         operation.HasGlyphKey);
+
                     break;
+
+                default:
+                    // Group control operations cannot be merged into a run path because
+                    // their exact position in the painted-layer stream defines isolation.
+                    return operations;
             }
         }
 
@@ -1787,12 +1804,13 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
     /// <param name="drawingOptions">Drawing options applied to each operation.</param>
     private void DrawTextOperations(List<DrawingOperation> operations, DrawingOptions drawingOptions)
     {
-        // Build composition commands and enforce render-pass ordering while preserving
-        // original emission order inside each pass. This preserves overlapping color-font
-        // layer compositing semantics (for example emoji mouth/teeth layers).
+        // Enforce render-pass ordering while preserving original emission order inside each
+        // pass. This preserves overlapping color-font layer compositing semantics (for
+        // example emoji mouth/teeth layers) and keeps the composite group markers paired
+        // with the fill operations they contain.
         // The cache-owned buffer keeps its capacity across draws; draw calls never overlap on
-        // one canvas, and the batcher retains the commands, not this buffer.
-        List<(byte RenderPass, int Sequence, CompositionSceneCommand Command)> entries = this.textCommandSortBuffer;
+        // one canvas.
+        List<(byte RenderPass, int Sequence)> entries = this.textOperationSortBuffer;
         entries.Clear();
 
         // Queued glyph commands never carry the canvas transform: glyph geometry arrives with
@@ -1805,8 +1823,7 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
 
         for (int i = 0; i < operations.Count; i++)
         {
-            DrawingOperation operation = operations[i];
-            entries.Add((operation.RenderPass, i, this.CreateTextCompositionCommand(operation, drawingOptions, sharedTextOptions)));
+            entries.Add((operations[i].RenderPass, i));
         }
 
         entries.Sort(static (a, b) =>
@@ -1815,21 +1832,82 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
             return cmp != 0 ? cmp : a.Sequence.CompareTo(b.Sequence);
         });
 
+        List<DrawingCanvasLayer> compositeLayers = this.textCompositeLayerStack;
+        compositeLayers.Clear();
+        DrawingCanvasState state = this.ResolveState();
+
         for (int i = 0; i < entries.Count; i++)
         {
-            if (entries[i].Command is PathCompositionSceneCommand pathCommand)
+            DrawingOperation operation = operations[entries[i].Sequence];
+            if (operation.Kind == DrawingOperationKind.BeginGroup)
+            {
+                GraphicsOptions layerOptions = CreateTextGroupOptions(operation, drawingOptions.GraphicsOptions);
+                DrawingCanvasLayer layer = new(layerOptions);
+                Rectangle layerBounds = operation.CompositeBounds;
+                layerBounds.Offset(state.DestinationOffset);
+
+                // Each group is exactly one isolated layer. Its blend modes apply when the
+                // group ends and the layer composites onto the content below it.
+                this.batcher.AddComposition(CompositionCommand.CreateBeginLayer(layerBounds, layer));
+                compositeLayers.Add(layer);
+                continue;
+            }
+
+            if (operation.Kind == DrawingOperationKind.EndGroup)
+            {
+                Rectangle layerBounds = operation.CompositeBounds;
+                layerBounds.Offset(state.DestinationOffset);
+
+                DrawingCanvasLayer layer = compositeLayers[^1];
+                compositeLayers.RemoveAt(compositeLayers.Count - 1);
+                this.batcher.AddComposition(CompositionCommand.CreateEndLayer(layerBounds, layer));
+                continue;
+            }
+
+            CompositionSceneCommand command = this.CreateTextCompositionCommand(
+                operation,
+                drawingOptions,
+                sharedTextOptions,
+                compositeLayers.Count > 0);
+
+            if (command is PathCompositionSceneCommand pathCommand)
             {
                 this.batcher.AddComposition(pathCommand.Command);
             }
             else
             {
-                this.batcher.AddStrokePath(((StrokePathCompositionSceneCommand)entries[i].Command).Command);
+                this.batcher.AddStrokePath(((StrokePathCompositionSceneCommand)command).Command);
             }
         }
 
-        // The buffer outlives the canvas (the text cache hosts it), so release the command
-        // references now rather than rooting the final draw's geometry until the next draw.
+        // The buffers outlive the canvas (the text cache hosts them), so drop the layer
+        // references now rather than rooting the final draw's state until the next draw.
         entries.Clear();
+        compositeLayers.Clear();
+    }
+
+    /// <summary>
+    /// Creates the graphics options used when a text group layer closes.
+    /// </summary>
+    /// <param name="operation">The group begin operation carrying the required modes.</param>
+    /// <param name="drawingOptions">The caller's graphics options.</param>
+    /// <returns>The options owned by the group layer.</returns>
+    private static GraphicsOptions CreateTextGroupOptions(
+        DrawingOperation operation,
+        GraphicsOptions drawingOptions)
+    {
+        GraphicsOptions result = drawingOptions.DeepClone();
+        if (!operation.ApplyDrawingOptions)
+        {
+            // Inner COLR groups compose at full strength with the group's own COLR modes.
+            // Only the outermost group applies caller opacity, preventing it from
+            // multiplying once per nesting level.
+            result.AlphaCompositionMode = operation.PixelAlphaCompositionMode;
+            result.ColorBlendingMode = operation.PixelColorBlendingMode;
+            result.BlendPercentage = 1F;
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -2146,8 +2224,15 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
     /// The identity-transform options shared by every operation of the draw whose graphics
     /// options match the canvas options.
     /// </param>
+    /// <param name="useFullOpacity">
+    /// Whether the operation is internal content of an isolated composite group.
+    /// </param>
     /// <returns>A composition scene command ready for batching.</returns>
-    private CompositionSceneCommand CreateTextCompositionCommand(DrawingOperation operation, DrawingOptions drawingOptions, DrawingOptions sharedTextOptions)
+    private CompositionSceneCommand CreateTextCompositionCommand(
+        DrawingOperation operation,
+        DrawingOptions drawingOptions,
+        DrawingOptions sharedTextOptions,
+        bool useFullOpacity)
     {
         Brush compositeBrush = operation.Kind == DrawingOperationKind.Fill
             ? operation.Brush!
@@ -2157,6 +2242,14 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
             drawingOptions.GraphicsOptions.CloneOrReturnForRules(
                 operation.PixelAlphaCompositionMode,
                 operation.PixelColorBlendingMode);
+
+        if (useFullOpacity && graphicsOptions.BlendPercentage != 1F)
+        {
+            // Caller opacity belongs to the outer isolated result. Applying it to group leaves
+            // would multiply the opacity once per paint and change the COLR composition.
+            graphicsOptions = graphicsOptions.DeepClone();
+            graphicsOptions.BlendPercentage = 1F;
+        }
 
         RasterizationMode rasterizationMode = graphicsOptions.Antialias
             ? RasterizationMode.Antialiased
@@ -2180,8 +2273,9 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
         Vector2 subPixelOffset = operation.SubPixelOffset;
 
         Pen? pen = operation.Kind == DrawingOperationKind.Draw ? operation.Pen : null;
+        IPath path = operation.Path!;
 
-        RectangleF bounds = operation.Path.Bounds;
+        RectangleF bounds = path.Bounds;
         bounds.Offset(subPixelOffset.X, subPixelOffset.Y);
         if (pen is not null)
         {
@@ -2199,6 +2293,16 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
             float inflate = MathF.Max(joinInflate, capInflate);
 
             bounds.Inflate(new SizeF(inflate, inflate));
+        }
+
+        // The font's clip bounds arrive as one canvas-space rectangle per glyph. The
+        // operation's interest is path-local, so shift the clip by the operation's integer
+        // location and narrow the bounds; the rasterizer then crops with no geometry work.
+        if (operation.GlyphClip.HasValue)
+        {
+            RectangleF glyphClip = operation.GlyphClip.Value;
+            glyphClip.Offset(-operation.RenderLocation.X, -operation.RenderLocation.Y);
+            bounds = RectangleF.Intersect(bounds, glyphClip);
         }
 
         Rectangle interest = ToRasterizerInterest(bounds);
@@ -2229,7 +2333,7 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
         {
             return new PathCompositionSceneCommand(
                 CompositionCommand.Create(
-                    operation.Path,
+                    path,
                     compositeBrush,
                     effectiveOptions,
                     in rasterizerOptions,
@@ -2241,7 +2345,7 @@ public sealed class DrawingCanvas<TPixel> : DrawingCanvas
 
         return new StrokePathCompositionSceneCommand(
             new StrokePathCommand(
-                operation.Path,
+                path,
                 compositeBrush,
                 effectiveOptions,
                 in rasterizerOptions,

--- a/src/ImageSharp.Drawing/Processing/DrawingOperation.cs
+++ b/src/ImageSharp.Drawing/Processing/DrawingOperation.cs
@@ -7,7 +7,7 @@ using SixLabors.ImageSharp.Drawing.Processing.Processors.Text;
 namespace SixLabors.ImageSharp.Drawing.Processing;
 
 /// <summary>
-/// Identifies how a text drawing operation paints its path.
+/// Identifies how a text drawing operation paints its path, or which group boundary it marks.
 /// </summary>
 internal enum DrawingOperationKind : byte
 {
@@ -19,25 +19,59 @@ internal enum DrawingOperationKind : byte
     /// <summary>
     /// The path is stroked using <see cref="DrawingOperation.Pen"/>.
     /// </summary>
-    Draw = 1
+    Draw = 1,
+
+    /// <summary>
+    /// Begins an isolated group.
+    /// </summary>
+    BeginGroup = 2,
+
+    /// <summary>
+    /// Ends the current group, blending it onto the content below it within its parent using
+    /// the modes captured by the matching <see cref="BeginGroup"/> operation.
+    /// </summary>
+    EndGroup = 3
 }
 
 /// <summary>
-/// Represents one paint operation emitted by <see cref="RichTextGlyphRenderer"/> during text
-/// rendering and later converted to composition commands by
-/// <see cref="DrawingCanvas{TPixel}"/>.
+/// Represents one paint or group-control operation emitted by
+/// <see cref="RichTextGlyphRenderer"/> during text rendering and later converted to
+/// composition commands by <see cref="DrawingCanvas{TPixel}"/>.
 /// </summary>
 internal struct DrawingOperation
 {
     /// <summary>
-    /// Gets or sets a value identifying whether the operation fills or strokes <see cref="Path"/>.
+    /// Gets or sets a value identifying whether the operation fills or strokes
+    /// <see cref="Path"/>, or which group boundary it marks.
     /// </summary>
     public DrawingOperationKind Kind { get; set; }
 
     /// <summary>
-    /// Gets or sets the glyph or decoration path in local coordinates relative to <see cref="RenderLocation"/>.
+    /// Gets or sets the glyph or decoration path in local coordinates relative to
+    /// <see cref="RenderLocation"/>. Group markers carry no geometry and leave
+    /// this <see langword="null"/>.
     /// </summary>
-    public IPath Path { get; set; }
+    public IPath? Path { get; set; }
+
+    /// <summary>
+    /// Gets or sets the canvas-local bounds of a group; the canvas offsets them
+    /// by its destination offset when the group is lowered to layer commands.
+    /// </summary>
+    public Rectangle CompositeBounds { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a group result uses the caller's graphics options
+    /// when it is added to the canvas. Only the outermost group of a glyph does, so caller
+    /// opacity applies once to the finished composition.
+    /// </summary>
+    public bool ApplyDrawingOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the canvas-local rectangle from the font's clip bounds, or
+    /// <see langword="null"/> when the glyph has none. The canvas narrows the operation's
+    /// rasterizer interest to it, so the clip costs one rectangle intersect.
+    /// </summary>
+    public RectangleF? GlyphClip { get; set; }
 
     /// <summary>
     /// Gets or sets the pixel-clamped target location at which <see cref="Path"/> is rendered.

--- a/src/ImageSharp.Drawing/Processing/DrawingTextCache.cs
+++ b/src/ImageSharp.Drawing/Processing/DrawingTextCache.cs
@@ -108,12 +108,17 @@ public sealed class DrawingTextCache
     internal List<DrawingOperation> OperationScratch { get; } = [];
 
     /// <summary>
-    /// Gets the reusable render-pass sort buffer used when text operations are lowered to
+    /// Gets the reusable render-pass sort buffer used before text operations are lowered to
     /// composition commands, hosted here for the same lifetime reason as
-    /// <see cref="OperationScratch"/>. The consuming batcher retains the commands, never this
-    /// buffer.
+    /// <see cref="OperationScratch"/>. Entries index into the operation list so the sort
+    /// moves pass and index pairs rather than whole operation structs.
     /// </summary>
-    internal List<(byte RenderPass, int Sequence, Backends.CompositionSceneCommand Command)> CommandSortScratch { get; } = [];
+    internal List<(byte RenderPass, int Sequence)> OperationSortScratch { get; } = [];
+
+    /// <summary>
+    /// Gets the reusable stack used to pair nested text composite layer commands.
+    /// </summary>
+    internal List<DrawingCanvasLayer> CompositeLayerScratch { get; } = [];
 
     /// <summary>
     /// Removes all cached text drawing data.
@@ -125,7 +130,8 @@ public sealed class DrawingTextCache
         this.runPathEntries.Clear();
         this.runPathUsage.Clear();
         this.OperationScratch.Clear();
-        this.CommandSortScratch.Clear();
+        this.OperationSortScratch.Clear();
+        this.CompositeLayerScratch.Clear();
     }
 
     /// <summary>

--- a/src/ImageSharp.Drawing/Processing/RichTextGlyphRenderer.cs
+++ b/src/ImageSharp.Drawing/Processing/RichTextGlyphRenderer.cs
@@ -12,6 +12,29 @@ using SixLabors.ImageSharp.Drawing.Text;
 namespace SixLabors.ImageSharp.Drawing.Processing.Processors.Text;
 
 /// <summary>
+/// Identifies which renderer callback a cached glyph entry replays. <see cref="Layer"/> is
+/// zero so pre-existing non-layered and ink-free entries keep their meaning under
+/// <see langword="default"/> initialization.
+/// </summary>
+internal enum GlyphCacheEntryKind : byte
+{
+    /// <summary>
+    /// A color layer, or the single entry of a non-layered glyph.
+    /// </summary>
+    Layer = 0,
+
+    /// <summary>
+    /// A marker opening an isolated group.
+    /// </summary>
+    BeginGroup = 1,
+
+    /// <summary>
+    /// A marker closing the current group.
+    /// </summary>
+    EndGroup = 2
+}
+
+/// <summary>
 /// Allows the rendering of rich text configured via <see cref="RichTextOptions"/>.
 /// </summary>
 internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
@@ -91,6 +114,32 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
     /// Set to <see langword="true"/> when <see cref="BeginLayer"/> is called, cleared in <see cref="EndGlyph"/>.
     /// </summary>
     private bool hasLayer;
+
+    /// <summary>
+    /// The transformed bounds used for isolated group layers in the current glyph.
+    /// </summary>
+    private Rectangle currentCompositeBounds;
+
+    /// <summary>
+    /// The nesting depth of open COLR groups. Zero identifies the outermost group and
+    /// root-level content, which alone apply the caller's graphics options.
+    /// </summary>
+    private int groupDepth;
+
+    /// <summary>
+    /// The canvas-local rectangle from the font's clip bounds, or <see langword="null"/>
+    /// when the current glyph has none. Stamped on every operation the glyph emits; the
+    /// canvas narrows each operation's rasterizer interest to it.
+    /// </summary>
+    private RectangleF? currentGlyphClip;
+
+    /// <summary>
+    /// The paint of the current color layer when <see cref="BeginLayer"/> converted it to a
+    /// brush, or <see langword="null"/> when the layer falls back to the run brush. Cached
+    /// layered replays store this paint so brush conversion can re-run per draw: paint
+    /// brushes bake device coordinates and cannot be reused across glyph positions.
+    /// </summary>
+    private Paint? currentLayerPaint;
 
     // --- Glyph outline cache ---
     // Glyphs that share the same CacheKey (same glyph id, size, pen reference, etc.) reuse
@@ -247,6 +296,42 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
             this.currentPen = null;
         }
 
+        // Group layer bounds must land where the glyph geometry lands: the builder
+        // transform carries any path-following placement composed onto the drawing
+        // transform, and brushes inside the glyph use that same transform.
+        RectangleF compositeBounds = RectangleF.Transform(
+            new RectangleF(bounds.Location, new SizeF(bounds.Width, bounds.Height)),
+            this.Builder.Transform);
+
+        this.currentCompositeBounds = Rectangle.FromLTRB(
+            (int)MathF.Floor(compositeBounds.Left),
+            (int)MathF.Floor(compositeBounds.Top),
+            (int)MathF.Ceiling(compositeBounds.Right),
+            (int)MathF.Ceiling(compositeBounds.Bottom));
+
+        this.groupDepth = 0;
+
+        // The font's clip bounds map to one device rectangle per glyph. Four corners cover
+        // every transform; under rotation the min-max rectangle is the tilted shape's Bounds,
+        // which keeps slightly too much area, and that area holds no paint. The rectangle is
+        // recomputed per draw because the clip transform carries the glyph's placement.
+        this.currentGlyphClip = null;
+        if (parameters.ClipBounds.HasValue)
+        {
+            ClipBounds clip = parameters.ClipBounds.Value;
+            Matrix4x4 clipTransform = new Matrix4x4(clip.Transform) * this.Builder.Transform;
+            FontRectangle clipRect = clip.Bounds;
+
+            Vector2 p0 = Vector2.Transform(new Vector2(clipRect.Left, clipRect.Top), clipTransform);
+            Vector2 p1 = Vector2.Transform(new Vector2(clipRect.Right, clipRect.Top), clipTransform);
+            Vector2 p2 = Vector2.Transform(new Vector2(clipRect.Right, clipRect.Bottom), clipTransform);
+            Vector2 p3 = Vector2.Transform(new Vector2(clipRect.Left, clipRect.Bottom), clipTransform);
+
+            Vector2 min = Vector2.Min(Vector2.Min(p0, p1), Vector2.Min(p2, p3));
+            Vector2 max = Vector2.Max(Vector2.Max(p0, p1), Vector2.Max(p2, p3));
+            this.currentGlyphClip = RectangleF.FromLTRB(min.X, min.Y, max.X, max.Y);
+        }
+
         if (!this.noCache)
         {
             // Transform the font-metric bounds by the drawing transform so that the size
@@ -254,8 +339,8 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
             // cached paths are position independent, and quantizing absorbs the float noise
             // that transformed sizes pick up under translation.
             RectangleF currentBounds = RectangleF.Transform(
-                   new RectangleF(bounds.Location, new SizeF(bounds.Width, bounds.Height)),
-                   this.drawingOptions.Transform);
+                new RectangleF(bounds.Location, new SizeF(bounds.Width, bounds.Height)),
+                this.drawingOptions.Transform);
 
             this.currentTransformedBoundsLocation = currentBounds.Location;
 
@@ -272,22 +357,30 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
             {
                 this.currentCacheEntries = cachedEntries;
 
-                if (cachedEntries.Count > 0 && !cachedEntries[0].IsLayered
-                    && this.EnabledDecorations() == TextDecorations.None)
+                if (cachedEntries.Count > 0 && this.EnabledDecorations() == TextDecorations.None)
                 {
-                    // Non-layered cache hit without decorations: emit operations directly
-                    // and tell the font engine to skip the outline entirely
-                    // (no MoveTo/LineTo/SetDecoration/EndGlyph).
-                    this.EmitCachedGlyphOperations(cachedEntries[0], currentBounds.Location);
+                    // Decoration-free cache hit: emit operations directly and tell the font
+                    // engine to skip the glyph entirely (no decode, no MoveTo/LineTo, no
+                    // layer or composite callbacks, no EndGlyph). Layered glyphs replay
+                    // their stored entry sequence; non-layered glyphs replay one entry.
+                    if (cachedEntries[0].IsLayered)
+                    {
+                        this.EmitCachedLayeredGlyphOperations(cachedEntries, currentBounds.Location);
+                    }
+                    else
+                    {
+                        this.EmitCachedGlyphOperations(cachedEntries[0], currentBounds.Location);
+                    }
+
                     return false;
                 }
 
-                // Layered or decorated cache hit: let the normal flow handle
-                // per-layer state and decoration callbacks. For decorated non-layered glyphs the
-                // decoded outline is not needed, because the cached path and its stored anchor
-                // position the glyph; skipping the build avoids a discarded path graph per glyph
-                // per draw. Layered glyphs keep building: each layer's exact built bounds anchor
-                // that layer, and COLR components interleave layers across glyph callbacks.
+                // Decorated cache hit: let the normal flow handle per-layer state and
+                // decoration callbacks, consuming one stored entry per callback. For
+                // decorated non-layered glyphs the decoded outline is not needed, because
+                // the cached path and its stored anchor position the glyph; skipping the
+                // build avoids a discarded path graph per glyph per draw. Decorated layered
+                // glyphs keep building: each layer's exact built bounds anchor that layer.
                 this.rasterizationRequired = false;
                 this.OutlineBuildRequired = cachedEntries[0].IsLayered;
                 return true;
@@ -299,17 +392,28 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
     }
 
     /// <inheritdoc/>
-    protected override void BeginLayer(Paint? paint, FillRule fillRule, ClipQuad? clipBounds)
+    protected override void BeginLayer(Paint? paint, FillRule fillRule)
     {
         // Capture the color-layer paint, fill rule, and composite mode.
         // Setting hasLayer tells EndGlyph to skip its default single-layer path emission.
         this.hasLayer = true;
         this.currentFillRule = fillRule;
+        this.currentLayerPaint = null;
         if (TryCreateBrush(paint, this.Builder.Transform, out Brush? brush))
         {
             this.currentBrush = brush;
+            this.currentLayerPaint = paint;
             this.currentCompositionMode = TextUtilities.MapCompositionMode(paint.CompositeMode);
             this.currentBlendingMode = TextUtilities.MapBlendingMode(paint.CompositeMode);
+        }
+        else if (this.groupDepth > 0)
+        {
+            // A layer inside an isolated group must never composite with the caller's
+            // modes: a destructive mode such as Src erases the group's accumulated
+            // backdrop. When the paint has no brush conversion the modes stay at their
+            // reset values, so pin plain source-over here.
+            this.currentCompositionMode = PixelAlphaCompositionMode.SrcOver;
+            this.currentBlendingMode = PixelColorBlendingMode.Normal;
         }
     }
 
@@ -334,16 +438,26 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
         // Any drawing of outlines is ignored as that doesn't really make sense.
         bool renderFill = this.currentBrush != null;
 
-        // Path has already been added to the collection via the base class. Layered glyphs
-        // always build their decoded outline, on hits too: each layer is anchored by its own
-        // exact built bounds, and COLR components interleave layers across glyph callbacks.
+        // Path has already been added to the collection via the base class, with any COLR
+        // clip box already intersected in, so the anchor below always describes the visible
+        // geometry and cached replays inherit the clip for free. Layered glyphs always build
+        // their decoded outline, on hits too: each layer is anchored by its own exact built
+        // bounds, and COLR components interleave layers across glyph callbacks.
         IPath path = this.CurrentPaths[^1];
+
         PointF boundsLocation = path.Bounds.Location;
         Point renderLocation = ClampToPixel(boundsLocation);
         Vector2 subPixelOffset = (Vector2)(boundsLocation - renderLocation);
         if (this.noCache || this.rasterizationRequired)
         {
+            // Capture everything a callback-free replay needs: the fill rule and paint are
+            // font data and bake safely; run-brush layers leave Paint null so the replay
+            // resolves the caller-dependent brush and modes live.
             renderData.IsLayered = true;
+            renderData.LayerFillRule = this.currentFillRule;
+            renderData.Paint = this.currentLayerPaint;
+            renderData.CompositionMode = this.currentCompositionMode;
+            renderData.BlendingMode = this.currentBlendingMode;
 
             if (path.Bounds.Equals(RectangleF.Empty))
             {
@@ -362,6 +476,10 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
                 renderData.FillPath = path.Translate(-boundsLocation.X, -boundsLocation.Y);
                 fillPath = renderData.FillPath;
             }
+
+            // The anchor offset lets replays estimate this layer's position from the fresh
+            // font-metric bounds alone, exactly like the non-layered replay.
+            renderData.BoundsOffset = (Vector2)(boundsLocation - this.currentTransformedBoundsLocation);
 
             if (!this.noCache)
             {
@@ -397,13 +515,57 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
                 Brush = this.currentBrush,
                 RenderPass = RenderOrderFill,
                 PixelAlphaCompositionMode = this.currentCompositionMode,
-                PixelColorBlendingMode = this.currentBlendingMode
+                PixelColorBlendingMode = this.currentBlendingMode,
+                GlyphClip = this.currentGlyphClip
             });
         }
 
         this.currentFillRule = FillRule.NonZero;
         this.currentCompositionMode = this.drawingOptions.GraphicsOptions.AlphaCompositionMode;
         this.currentBlendingMode = this.drawingOptions.GraphicsOptions.ColorBlendingMode;
+        this.currentLayerPaint = null;
+    }
+
+    /// <inheritdoc/>
+    protected override void BeginGroup(CompositeMode mode)
+    {
+        this.DrawingOperations.Add(new DrawingOperation
+        {
+            Kind = DrawingOperationKind.BeginGroup,
+            CompositeBounds = this.currentCompositeBounds,
+            RenderPass = RenderOrderFill,
+            ApplyDrawingOptions = this.groupDepth == 0,
+            PixelAlphaCompositionMode = TextUtilities.MapCompositionMode(mode),
+            PixelColorBlendingMode = TextUtilities.MapBlendingMode(mode)
+        });
+
+        this.RecordMarker(new GlyphRenderData
+        {
+            IsLayered = true,
+            EntryKind = GlyphCacheEntryKind.BeginGroup,
+            CompositionMode = TextUtilities.MapCompositionMode(mode),
+            BlendingMode = TextUtilities.MapBlendingMode(mode)
+        });
+
+        this.groupDepth++;
+    }
+
+    /// <inheritdoc/>
+    protected override void EndGroup()
+    {
+        this.groupDepth--;
+        this.DrawingOperations.Add(new DrawingOperation
+        {
+            Kind = DrawingOperationKind.EndGroup,
+            CompositeBounds = this.currentCompositeBounds,
+            RenderPass = RenderOrderFill
+        });
+
+        this.RecordMarker(new GlyphRenderData
+        {
+            IsLayered = true,
+            EntryKind = GlyphCacheEntryKind.EndGroup
+        });
     }
 
     /// <inheritdoc/>
@@ -606,7 +768,8 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
                 Brush = this.currentBrush,
                 RenderPass = RenderOrderFill,
                 PixelAlphaCompositionMode = this.currentCompositionMode,
-                PixelColorBlendingMode = this.currentBlendingMode
+                PixelColorBlendingMode = this.currentBlendingMode,
+                GlyphClip = this.currentGlyphClip
             });
         }
 
@@ -625,7 +788,8 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
                 Pen = this.currentPen,
                 RenderPass = RenderOrderOutline,
                 PixelAlphaCompositionMode = this.currentCompositionMode,
-                PixelColorBlendingMode = this.currentBlendingMode
+                PixelColorBlendingMode = this.currentBlendingMode,
+                GlyphClip = this.currentGlyphClip
             });
         }
     }
@@ -681,7 +845,8 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
                 Brush = brush,
                 RenderPass = RenderOrderFill,
                 PixelAlphaCompositionMode = this.currentCompositionMode,
-                PixelColorBlendingMode = this.currentBlendingMode
+                PixelColorBlendingMode = this.currentBlendingMode,
+                GlyphClip = this.currentGlyphClip
             });
         }
 
@@ -700,17 +865,181 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
                 Pen = pen,
                 RenderPass = RenderOrderOutline,
                 PixelAlphaCompositionMode = this.currentCompositionMode,
-                PixelColorBlendingMode = this.currentBlendingMode
+                PixelColorBlendingMode = this.currentBlendingMode,
+                GlyphClip = this.currentGlyphClip
             });
         }
     }
 
     /// <summary>
+    /// Emits the complete <see cref="DrawingOperation"/> sequence for a layered (COLR) glyph
+    /// from its cached entry stream. Called from <see cref="BeginGlyph"/> on a
+    /// decoration-free cache hit when the font engine is told to skip the glyph entirely,
+    /// so no outline is decoded and no path graph is built. Geometry replays from the
+    /// anchored per-layer paths, group bounds and the glyph clip are recomputed per draw,
+    /// and paint brushes re-convert with the glyph's positional delta appended to the
+    /// drawing transform, because converted brushes bake device coordinates.
+    /// </summary>
+    /// <param name="entries">The cached entry stream recorded by the build draw.</param>
+    /// <param name="currentBoundsLocation">The transformed bounding-box origin for the current glyph instance.</param>
+    private void EmitCachedLayeredGlyphOperations(List<GlyphRenderData> entries, PointF currentBoundsLocation)
+    {
+        Vector2 currentOrigin = currentBoundsLocation;
+        Vector2 delta = currentOrigin - entries[0].SourceOrigin;
+        Matrix4x4 paintTransform = this.drawingOptions.Transform * Matrix4x4.CreateTranslation(delta.X, delta.Y, 0F);
+        int replayDepth = 0;
+
+        for (int i = 0; i < entries.Count; i++)
+        {
+            GlyphRenderData entry = entries[i];
+            switch (entry.EntryKind)
+            {
+                case GlyphCacheEntryKind.BeginGroup:
+                    this.DrawingOperations.Add(new DrawingOperation
+                    {
+                        Kind = DrawingOperationKind.BeginGroup,
+                        CompositeBounds = this.currentCompositeBounds,
+                        RenderPass = RenderOrderFill,
+                        ApplyDrawingOptions = replayDepth == 0,
+                        PixelAlphaCompositionMode = entry.CompositionMode,
+                        PixelColorBlendingMode = entry.BlendingMode
+                    });
+
+                    replayDepth++;
+                    break;
+
+                case GlyphCacheEntryKind.EndGroup:
+                    this.DrawingOperations.Add(new DrawingOperation
+                    {
+                        Kind = DrawingOperationKind.EndGroup,
+                        CompositeBounds = this.currentCompositeBounds,
+                        RenderPass = RenderOrderFill
+                    });
+
+                    replayDepth--;
+                    break;
+
+                default:
+                    this.EmitCachedLayerFill(entry, currentBoundsLocation, paintTransform, replayDepth);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Emits one cached color layer at the current glyph position. Brush and mode
+    /// resolution mirrors <see cref="BeginLayer"/> and <see cref="EndLayer"/>: paint layers
+    /// re-convert their paint and use its baked modes, and run-brush layers resolve the
+    /// caller's brush and modes live, with group content pinned to plain source-over.
+    /// </summary>
+    /// <param name="entry">The cached layer entry.</param>
+    /// <param name="currentBoundsLocation">The transformed bounding-box origin for the current glyph instance.</param>
+    /// <param name="paintTransform">The drawing transform with the glyph's positional delta appended.</param>
+    /// <param name="replayDepth">The current group nesting depth.</param>
+    private void EmitCachedLayerFill(GlyphRenderData entry, PointF currentBoundsLocation, Matrix4x4 paintTransform, int replayDepth)
+    {
+        if (entry.FillPath is null)
+        {
+            // Ink-free layer marker: the build emitted nothing for it either.
+            return;
+        }
+
+        PointF estimatedPathLocation = new(
+            currentBoundsLocation.X + entry.BoundsOffset.X,
+            currentBoundsLocation.Y + entry.BoundsOffset.Y);
+
+        Point renderLocation = ClampToPixel(estimatedPathLocation);
+        Vector2 subPixelOffset = (Vector2)(estimatedPathLocation - renderLocation);
+
+        Brush? brush;
+        PixelAlphaCompositionMode compositionMode;
+        PixelColorBlendingMode blendingMode;
+        if (entry.Paint is not null && TryCreateBrush(entry.Paint, paintTransform, out Brush? paintBrush))
+        {
+            brush = paintBrush;
+            compositionMode = entry.CompositionMode;
+            blendingMode = entry.BlendingMode;
+        }
+        else
+        {
+            // Same fallback ladder as EndLayer: the run brush, then the draw default when no
+            // pen claims the glyph, with group content pinned to plain source-over so
+            // destructive caller modes cannot erase the isolated backdrop.
+            brush = this.currentBrush;
+            if (brush is null && this.currentPen is null)
+            {
+                brush = this.defaultBrush;
+            }
+
+            if (replayDepth > 0)
+            {
+                compositionMode = PixelAlphaCompositionMode.SrcOver;
+                blendingMode = PixelColorBlendingMode.Normal;
+            }
+            else
+            {
+                compositionMode = this.drawingOptions.GraphicsOptions.AlphaCompositionMode;
+                blendingMode = this.drawingOptions.GraphicsOptions.ColorBlendingMode;
+            }
+        }
+
+        if (brush is null)
+        {
+            return;
+        }
+
+        this.DrawingOperations.Add(new DrawingOperation
+        {
+            Kind = DrawingOperationKind.Fill,
+            Path = entry.FillPath,
+            RenderLocation = renderLocation,
+            SubPixelOffset = subPixelOffset,
+            GlyphKey = this.currentCacheKey,
+            HasGlyphKey = true,
+            IntersectionRule = TextUtilities.MapFillRule(entry.LayerFillRule),
+            Brush = brush,
+            RenderPass = RenderOrderFill,
+            PixelAlphaCompositionMode = compositionMode,
+            PixelColorBlendingMode = blendingMode,
+            GlyphClip = this.currentGlyphClip
+        });
+    }
+
+    /// <summary>
+    /// Records one non-layer callback in the glyph cache stream. On a build this appends
+    /// the marker entry; on a decorated cache hit it consumes the matching stored entry so
+    /// the per-callback read index stays aligned with the font engine's sequence.
+    /// </summary>
+    /// <param name="entry">The marker entry to append on a build.</param>
+    private void RecordMarker(GlyphRenderData entry)
+    {
+        if (this.noCache)
+        {
+            return;
+        }
+
+        if (this.rasterizationRequired)
+        {
+            this.UpdateCache(entry);
+        }
+        else if (this.currentCacheEntries is not null)
+        {
+            this.cacheReadIndex++;
+        }
+    }
+
+    /// <summary>
     /// Stores a <see cref="GlyphRenderData"/> entry in the glyph cache under the
-    /// current key. Creates the cache list on first insertion for a given key.
+    /// current key. Creates the cache list on first insertion for a given key. Every entry
+    /// is stamped with the glyph's build-time transformed metric origin so layered replays
+    /// can derive the positional delta for paint brushes.
     /// </summary>
     /// <param name="renderData">The render data to append to the current key's entry list.</param>
-    private void UpdateCache(GlyphRenderData renderData) => this.glyphCache.GetOrAdd(this.currentCacheKey).Add(renderData);
+    private void UpdateCache(GlyphRenderData renderData)
+    {
+        renderData.SourceOrigin = this.currentTransformedBoundsLocation;
+        this.glyphCache.GetOrAdd(this.currentCacheKey).Add(renderData);
+    }
 
     /// <summary>
     /// Truncates a floating-point position to the nearest whole pixel toward negative infinity.
@@ -762,9 +1091,46 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
         /// <see langword="true"/> if this entry belongs to a multi-layer (COLR) glyph.
         /// Non-layered cache hits with no decorations can skip the outline entirely
         /// (return <see langword="false"/> from <see cref="BeginGlyph"/>); layered hits
-        /// still need the per-layer <c>BeginLayer</c>/<c>EndLayer</c> callbacks.
+        /// replay the stored entry sequence, and decorated hits still walk the callbacks
+        /// consuming one entry per callback.
         /// </summary>
         public bool IsLayered;
+
+        /// <summary>
+        /// Identifies which callback this entry replays. Layer entries carry geometry;
+        /// marker entries reproduce the composite group structure.
+        /// </summary>
+        public GlyphCacheEntryKind EntryKind;
+
+        /// <summary>
+        /// The fill rule captured for a layer entry.
+        /// </summary>
+        public FillRule LayerFillRule;
+
+        /// <summary>
+        /// The COLR paint for a layer entry, or <see langword="null"/> when the layer uses
+        /// the run brush. Paints are re-converted to brushes on every replay because
+        /// converted brushes bake device coordinates for the build position.
+        /// </summary>
+        public Paint? Paint;
+
+        /// <summary>
+        /// The alpha composition mode baked from font data. Valid for layer entries whose
+        /// <see cref="Paint"/> is set and for <see cref="GlyphCacheEntryKind.BeginGroup"/>
+        /// markers; all other entries resolve caller-dependent modes live at replay.
+        /// </summary>
+        public PixelAlphaCompositionMode CompositionMode;
+
+        /// <summary>
+        /// The color blending mode baked from font data, paired with <see cref="CompositionMode"/>.
+        /// </summary>
+        public PixelColorBlendingMode BlendingMode;
+
+        /// <summary>
+        /// The glyph's transformed metric-bounds origin at build time. Replays subtract this
+        /// from the current origin to translate paint brushes to the new position.
+        /// </summary>
+        public Vector2 SourceOrigin;
     }
 
     /// <summary>

--- a/src/ImageSharp.Drawing/Text/BaseGlyphBuilder.cs
+++ b/src/ImageSharp.Drawing/Text/BaseGlyphBuilder.cs
@@ -121,11 +121,6 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
     private FillRule currentLayerFillRule;
 
     /// <summary>
-    /// Clip quad supplied by <c>BeginLayer</c> (COLR v1); applied in <c>EndLayer</c>.
-    /// </summary>
-    private ClipQuad? currentClipBounds;
-
-    /// <summary>
     /// Dedicated builder for carved decoration segments. The sliding window emits a glyph's
     /// segments after the next glyph has already retargeted <see cref="Builder"/> (path text
     /// sets a per-glyph transform), so decoration geometry is built here under the transform
@@ -314,7 +309,6 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
         this.layerStartIndex = this.graphemePathCount;
         this.currentLayerPaint = null;
         this.currentLayerFillRule = FillRule.NonZero;
-        this.currentClipBounds = null;
         return this.BeginGlyph(in bounds, in parameters);
     }
 
@@ -326,7 +320,7 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
         // renderer, so dropping the geometry here loses nothing.
         if (this.OutlineBuildRequired)
         {
-            this.Builder.StartFigure();
+            _ = this.Builder.StartFigure();
         }
     }
 
@@ -335,7 +329,7 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
     {
         if (this.OutlineBuildRequired)
         {
-            this.Builder.AddCubicBezier(this.currentPoint, secondControlPoint, thirdControlPoint, point);
+            _ = this.Builder.AddCubicBezier(this.currentPoint, secondControlPoint, thirdControlPoint, point);
         }
 
         this.currentPoint = point;
@@ -385,7 +379,7 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
     {
         if (this.OutlineBuildRequired)
         {
-            this.Builder.CloseFigure();
+            _ = this.Builder.CloseFigure();
         }
     }
 
@@ -394,7 +388,7 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
     {
         if (this.OutlineBuildRequired)
         {
-            this.Builder.AddLine(this.currentPoint, point);
+            _ = this.Builder.AddLine(this.currentPoint, point);
         }
 
         this.currentPoint = point;
@@ -405,7 +399,7 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
     {
         if (this.OutlineBuildRequired)
         {
-            this.Builder.StartFigure();
+            _ = this.Builder.StartFigure();
         }
 
         this.currentPoint = point;
@@ -416,7 +410,7 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
     {
         if (this.OutlineBuildRequired)
         {
-            this.Builder.AddArc(this.currentPoint, radiusX, radiusY, rotation, largeArc, sweep, point);
+            _ = this.Builder.AddArc(this.currentPoint, radiusX, radiusY, rotation, largeArc, sweep, point);
         }
 
         this.currentPoint = point;
@@ -427,7 +421,7 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
     {
         if (this.OutlineBuildRequired)
         {
-            this.Builder.AddQuadraticBezier(this.currentPoint, secondControlPoint, point);
+            _ = this.Builder.AddQuadraticBezier(this.currentPoint, secondControlPoint, point);
         }
 
         this.currentPoint = point;
@@ -439,24 +433,22 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
     /// </summary>
     /// <param name="paint">The paint for this color layer, or <see langword="null"/> for the default foreground.</param>
     /// <param name="fillRule">The fill rule to use when rasterizing this layer.</param>
-    /// <param name="clipBounds">Optional clip quad constraining the layer region.</param>
-    void IGlyphRenderer.BeginLayer(Paint? paint, FillRule fillRule, ClipQuad? clipBounds)
+    void IGlyphRenderer.BeginLayer(Paint? paint, FillRule fillRule)
     {
         this.usedLayers = true;
         this.inLayer = true;
         this.layerStartIndex = this.graphemePathCount;
         this.currentLayerPaint = paint;
         this.currentLayerFillRule = fillRule;
-        this.currentClipBounds = clipBounds;
 
         this.Builder.Clear();
-        this.BeginLayer(paint, fillRule, clipBounds);
+        this.BeginLayer(paint, fillRule);
     }
 
     /// <summary>
     /// Called by the font engine to close a color layer opened by <c>BeginLayer</c>.
-    /// Builds the layer path, applies any clip quad, and registers the result
-    /// as a painted layer in the current grapheme aggregate.
+    /// Builds the layer path and registers the result as a painted layer in the current
+    /// grapheme aggregate.
     /// </summary>
     void IGlyphRenderer.EndLayer()
     {
@@ -470,18 +462,6 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
         if (this.OutlineBuildRequired)
         {
             IPath path = this.Builder.Build();
-
-            // If the layer defines a clip quad (e.g. from COLR v1), intersect the
-            // built path with the quad polygon to constrain rendering.
-            if (this.currentClipBounds is not null)
-            {
-                ClipQuad clip = this.currentClipBounds.Value;
-                PointF[] points = [clip.TopLeft, clip.TopRight, clip.BottomRight, clip.BottomLeft];
-                LinearLineSegment segment = new(points);
-                Polygon polygon = new(segment);
-
-                path = path.Clip(BooleanOperation.Intersection, TextUtilities.MapFillRule(this.currentLayerFillRule), polygon);
-            }
 
             this.CurrentPaths.Add(path);
 
@@ -504,9 +484,14 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
         this.inLayer = false;
         this.currentLayerPaint = null;
         this.currentLayerFillRule = FillRule.NonZero;
-        this.currentClipBounds = null;
         this.EndLayer();
     }
+
+    /// <inheritdoc/>
+    void IGlyphRenderer.BeginGroup(CompositeMode mode) => this.BeginGroup(mode);
+
+    /// <inheritdoc/>
+    void IGlyphRenderer.EndGroup() => this.EndGroup();
 
     /// <summary>
     /// Called by the font engine to report a text decoration (underline, strikeout, or overline)
@@ -868,10 +853,10 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
         // The sampled frames replace the per-glyph placement transforms, but the builder's
         // default transform still applies on top, exactly as it does for glyph geometry.
         this.decorationBuilder.Clear();
-        this.decorationBuilder.SetTransform(this.baseTransform);
-        this.decorationBuilder.StartFigure();
-        this.decorationBuilder.AddLines(outline);
-        this.decorationBuilder.CloseFigure();
+        _ = this.decorationBuilder.SetTransform(this.baseTransform);
+        _ = this.decorationBuilder.StartFigure();
+        _ = this.decorationBuilder.AddLines(outline);
+        _ = this.decorationBuilder.CloseFigure();
 
         IPath path = this.decorationBuilder.Build();
         this.decorationBuilder.Clear();
@@ -922,12 +907,12 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
         // Snap the corners to whole pixels on the cross axis only, keeping the stroke's edges crisp;
         // the along-line coordinates stay exact so skip-ink gap boundaries land symmetrically.
         this.decorationBuilder.Clear();
-        this.decorationBuilder.SetTransform(transform);
-        this.decorationBuilder.StartFigure();
-        this.decorationBuilder.AddLine(SnapCross(a + offset, rotated), SnapCross(b + offset, rotated));
-        this.decorationBuilder.AddLine(SnapCross(b + offset, rotated), SnapCross(c + offset, rotated));
-        this.decorationBuilder.AddLine(SnapCross(c + offset, rotated), SnapCross(d + offset, rotated));
-        this.decorationBuilder.CloseFigure();
+        _ = this.decorationBuilder.SetTransform(transform);
+        _ = this.decorationBuilder.StartFigure();
+        _ = this.decorationBuilder.AddLine(SnapCross(a + offset, rotated), SnapCross(b + offset, rotated));
+        _ = this.decorationBuilder.AddLine(SnapCross(b + offset, rotated), SnapCross(c + offset, rotated));
+        _ = this.decorationBuilder.AddLine(SnapCross(c + offset, rotated), SnapCross(d + offset, rotated));
+        _ = this.decorationBuilder.CloseFigure();
 
         IPath path = this.decorationBuilder.Build();
 
@@ -1017,7 +1002,7 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
         // Translate so the glyph's top-left aligns with the path point,
         // then rotate around the path point to follow the tangent.
         Vector2 translation = (Vector2)pathPoint.Point - bounds.Location - half + new Vector2(0, bounds.Top);
-        this.Builder.SetTransform(
+        _ = this.Builder.SetTransform(
             Matrix4x4.CreateTranslation(translation.X, translation.Y, 0)
             * new Matrix4x4(Matrix3x2.CreateRotation(angle, (Vector2)pathPoint.Point)));
     }
@@ -1063,8 +1048,7 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
     /// </summary>
     /// <param name="paint">The paint for this color layer, or <see langword="null"/> for the default foreground.</param>
     /// <param name="fillRule">The fill rule to use when rasterizing this layer.</param>
-    /// <param name="clipBounds">Optional clip quad constraining the layer region.</param>
-    protected virtual void BeginLayer(Paint? paint, FillRule fillRule, ClipQuad? clipBounds)
+    protected virtual void BeginLayer(Paint? paint, FillRule fillRule)
     {
     }
 
@@ -1073,6 +1057,22 @@ internal class BaseGlyphBuilder : IGlyphRenderer, IDisposable
     /// emit the layer as a drawing operation.
     /// </summary>
     protected virtual void EndLayer()
+    {
+    }
+
+    /// <summary>
+    /// Called when an isolated COLR group begins. Layers and nested groups painted before the
+    /// matching <see cref="EndGroup"/> compose as one unit.
+    /// </summary>
+    /// <param name="mode">The mode used to blend the finished group onto the content below it within its parent.</param>
+    protected virtual void BeginGroup(CompositeMode mode)
+    {
+    }
+
+    /// <summary>
+    /// Called when the current isolated COLR group ends.
+    /// </summary>
+    protected virtual void EndGroup()
     {
     }
 

--- a/src/ImageSharp.Drawing/Text/TextUtilities.cs
+++ b/src/ImageSharp.Drawing/Text/TextUtilities.cs
@@ -55,6 +55,7 @@ internal static class TextUtilities
             CompositeMode.SrcAtop => PixelAlphaCompositionMode.SrcAtop,
             CompositeMode.DestAtop => PixelAlphaCompositionMode.DestAtop,
             CompositeMode.Xor => PixelAlphaCompositionMode.Xor,
+            CompositeMode.Plus => PixelAlphaCompositionMode.Plus,
             _ => PixelAlphaCompositionMode.SrcOver,
         };
 
@@ -69,18 +70,21 @@ internal static class TextUtilities
     public static PixelColorBlendingMode MapBlendingMode(CompositeMode mode)
         => mode switch
         {
-            CompositeMode.Plus => PixelColorBlendingMode.Add,
             CompositeMode.Screen => PixelColorBlendingMode.Screen,
             CompositeMode.Overlay => PixelColorBlendingMode.Overlay,
             CompositeMode.Darken => PixelColorBlendingMode.Darken,
             CompositeMode.Lighten => PixelColorBlendingMode.Lighten,
             CompositeMode.HardLight => PixelColorBlendingMode.HardLight,
             CompositeMode.Multiply => PixelColorBlendingMode.Multiply,
-
-            // TODO: We do not support the following separate alpha blending modes:
-            // - ColorDodge, ColorBurn, SoftLight, Difference, Exclusion
-            // TODO: We do not support the non-alpha blending modes.
-            // - Hue, Saturation, Color, Luminosity
+            CompositeMode.ColorDodge => PixelColorBlendingMode.ColorDodge,
+            CompositeMode.ColorBurn => PixelColorBlendingMode.ColorBurn,
+            CompositeMode.SoftLight => PixelColorBlendingMode.SoftLight,
+            CompositeMode.Difference => PixelColorBlendingMode.Difference,
+            CompositeMode.Exclusion => PixelColorBlendingMode.Exclusion,
+            CompositeMode.Hue => PixelColorBlendingMode.Hue,
+            CompositeMode.Saturation => PixelColorBlendingMode.Saturation,
+            CompositeMode.Color => PixelColorBlendingMode.Color,
+            CompositeMode.Luminosity => PixelColorBlendingMode.Luminosity,
             _ => PixelColorBlendingMode.Normal
         };
 

--- a/tests/ImageSharp.Drawing.Tests/Processing/Backends/FineAreaComputeShaderTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Processing/Backends/FineAreaComputeShaderTests.cs
@@ -29,7 +29,7 @@ public class FineAreaComputeShaderTests
         Assert.Contains("fn decode_target(color: vec4<f32>) -> vec4<f32> {\n    return decode_numeric(color);\n}", source);
         Assert.Contains("fn encode_target(color: vec4<f32>) -> vec4<f32> {\n    return encode_numeric(color);\n}", source);
         Assert.Contains("rgba[i] = decode_target(backdrop_raw);", source);
-        Assert.Contains("textureStore(output, vec2<i32>(coords), encode_target(rgba[i]));", source);
+        Assert.Contains("textureStore(output, vec2<i32>(coords), round_trip_target_format(encode_target(rgba[i])));", source);
     }
 
     [Fact]
@@ -38,8 +38,8 @@ public class FineAreaComputeShaderTests
         string source = GetSource(TextureFormat.RGBA8Unorm, PixelAlphaRepresentation.Unassociated, WebGPUTargetNumericEncoding.Unit);
 
         Assert.Contains("return premul_alpha(decode_numeric(color));", source);
-        Assert.Contains("let a_inv = select(0.0, 1.0 / color.a, color.a > 0.0);", source);
-        Assert.Contains("return encode_numeric(vec4<f32>(color.rgb * a_inv, color.a));", source);
+        Assert.Contains("if color.a == 0.0 {\n        return encode_numeric(color);\n    }", source);
+        Assert.Contains("return encode_numeric(vec4<f32>(color.rgb / color.a, color.a));", source);
     }
 
     [Fact]
@@ -58,6 +58,11 @@ public class FineAreaComputeShaderTests
 
         Assert.Contains("fn decode_numeric(color: vec4<f32>) -> vec4<f32> {\n    return color;\n}", source);
         Assert.Contains("fn encode_numeric(color: vec4<f32>) -> vec4<f32> {\n    return color;\n}", source);
+
+        // Binary16 stores quantize in-shader with round-to-nearest-even so the hardware
+        // conversion is lossless and matches the CPU renderer's float-to-half rounding.
+        Assert.Contains("textureStore(output, vec2<i32>(coords), round_trip_target_format(encode_target(rgba[i])));", source);
+        Assert.Contains("return vec4<f32>(quantize_f16_rtne(color.x), quantize_f16_rtne(color.y), quantize_f16_rtne(color.z), quantize_f16_rtne(color.w));", source);
     }
 
     private static string GetSource(

--- a/tests/ImageSharp.Drawing.Tests/Processing/Backends/WebGPUDrawingBackendTests.Blending.cs
+++ b/tests/ImageSharp.Drawing.Tests/Processing/Backends/WebGPUDrawingBackendTests.Blending.cs
@@ -1,0 +1,505 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using System.Numerics;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Drawing.Processing.Backends;
+using SixLabors.ImageSharp.Drawing.Tests.TestUtilities.Attributes;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Drawing.Tests.Processing.Backends;
+
+public partial class WebGPUDrawingBackendTests
+{
+    /// <summary>
+    /// Gets the COLR blend modes used by realistic brush-rendering parity tests.
+    /// </summary>
+    public static TheoryData<PixelColorBlendingMode, PixelAlphaCompositionMode> NewGraphicsOptionsModePairs { get; } =
+    new()
+    {
+        { PixelColorBlendingMode.ColorDodge, PixelAlphaCompositionMode.SrcOver },
+        { PixelColorBlendingMode.ColorBurn, PixelAlphaCompositionMode.SrcOver },
+        { PixelColorBlendingMode.SoftLight, PixelAlphaCompositionMode.SrcOver },
+        { PixelColorBlendingMode.Difference, PixelAlphaCompositionMode.SrcOver },
+        { PixelColorBlendingMode.Exclusion, PixelAlphaCompositionMode.SrcOver },
+        { PixelColorBlendingMode.Hue, PixelAlphaCompositionMode.SrcOver },
+        { PixelColorBlendingMode.Saturation, PixelAlphaCompositionMode.SrcOver },
+        { PixelColorBlendingMode.Color, PixelAlphaCompositionMode.SrcOver },
+        { PixelColorBlendingMode.Luminosity, PixelAlphaCompositionMode.SrcOver },
+        { PixelColorBlendingMode.Normal, PixelAlphaCompositionMode.Plus }
+    };
+
+    /// <summary>
+    /// Gets every new color blend mode paired with every public alpha composition mode.
+    /// </summary>
+    public static TheoryData<PixelColorBlendingMode, PixelAlphaCompositionMode> NewColorBlendCompositionPairs { get; }
+        = CreateNewColorBlendCompositionPairs();
+
+    /// <summary>
+    /// Verifies that WebGPU produces the same pixels as the default CPU backend for every new blend/composition pairing.
+    /// </summary>
+    /// <param name="colorMode">The color blend mode to test.</param>
+    /// <param name="alphaMode">The alpha composition mode to test.</param>
+    [WebGPUTheory]
+    [MemberData(nameof(NewColorBlendCompositionPairs))]
+    public void NewColorBlendModes_WithEveryAlphaCompositionMode_MatchDefaultOutput(
+        PixelColorBlendingMode colorMode,
+        PixelAlphaCompositionMode alphaMode)
+    {
+        DrawingOptions drawingOptions = new()
+        {
+            GraphicsOptions = new GraphicsOptions
+            {
+                Antialias = false,
+                // 0.2 is exactly representable in the scene's 16-bit BlendPercentage
+                // encoding, so both backends compose with the identical opacity.
+                BlendPercentage = 0.2F,
+                ColorBlendingMode = colorMode,
+                AlphaCompositionMode = alphaMode
+            }
+        };
+
+        using Image<Rgba32> baseImage = new(8, 8, new Rgba32(42, 106, 181, 173));
+        using Image<Rgba32> defaultImage = baseImage.Clone();
+
+        // An image source reaches both backends as identical stored bytes: the CPU brush
+        // samples them directly and the GPU samples the same texels from the image atlas.
+        // A solid brush cannot make that guarantee, because the CPU quantizes its color
+        // through the target pixel format while the scene wire carries associated binary16.
+        using Image<Rgba32> sourceImage = new(8, 8, new Rgba32(218, 71, 133, 157));
+        ImageBrush<Rgba32> brush = new(sourceImage, new RectangleF(0, 0, 8, 8), Point.Empty);
+        RectanglePolygon rectangle = new(0, 0, 8, 8);
+
+        void DrawAction(DrawingCanvas canvas) => canvas.Fill(brush, rectangle);
+
+        RenderWithDefaultBackend(defaultImage, drawingOptions, DrawAction);
+
+        using WebGPUDrawingBackend backend = new();
+        using Image<Rgba32> webGPUImage = RenderWithNativeSurfaceWebGpuBackend(
+            defaultImage.Width,
+            defaultImage.Height,
+            backend,
+            drawingOptions,
+            DrawAction,
+            baseImage);
+
+        // A zero tolerance makes the CPU output the reference for every rendered pixel.
+        AssertBackendPairSimilarity(defaultImage, webGPUImage, 0F);
+    }
+
+    /// <summary>
+    /// Verifies that binary16 targets store the same blended pixels as the default CPU renderer.
+    /// </summary>
+    /// <param name="colorMode">The color blend mode to test.</param>
+    /// <param name="alphaMode">The alpha composition mode to test.</param>
+    [WebGPUTheory]
+    [MemberData(nameof(NewGraphicsOptionsModePairs))]
+    public void NewBlendModes_SolidBrush_RgbaHalfTargetMatchesDefaultOutput(
+        PixelColorBlendingMode colorMode,
+        PixelAlphaCompositionMode alphaMode)
+    {
+        DrawingOptions drawingOptions = new()
+        {
+            GraphicsOptions = new GraphicsOptions
+            {
+                Antialias = false,
+                // Full opacity isolates target-pixel conversion and blend math from the scene
+                // format's established 16-bit BlendPercentage encoding.
+                BlendPercentage = 1F,
+                ColorBlendingMode = colorMode,
+                AlphaCompositionMode = alphaMode
+            }
+        };
+
+        // Binary-exact components prevent the helper's initial-image upload from introducing a
+        // pre-blend half-precision difference between the two backends.
+        RgbaHalf backdrop = Color.FromScaledVector(new Vector4(0.25F, 0.5F, 0.75F, 1F)).ToPixel<RgbaHalf>();
+        using Image<RgbaHalf> baseImage = new(8, 8, backdrop);
+        using Image<RgbaHalf> defaultImage = baseImage.Clone();
+        SolidBrush brush = Brushes.Solid(Color.FromScaledVector(new Vector4(0.75F, 0.25F, 0.625F, 0.625F)));
+        RectanglePolygon rectangle = new(-1, -1, 10, 10);
+
+        void DrawAction(DrawingCanvas canvas) => canvas.Fill(brush, rectangle);
+
+        RenderWithDefaultBackend(defaultImage, drawingOptions, DrawAction);
+
+        using WebGPUDrawingBackend backend = new();
+        using Image<RgbaHalf> webGPUImage = RenderWithNativeSurfaceWebGpuBackend(
+            defaultImage.Width,
+            defaultImage.Height,
+            backend,
+            WebGPUTextureFormat.Rgba16Float,
+            drawingOptions,
+            DrawAction,
+            baseImage);
+
+        // The CPU image is the executable reference, including its binary16 storage conversion.
+        AssertBackendPairSimilarity(defaultImage, webGPUImage, 0F);
+    }
+
+    /// <summary>
+    /// Verifies realistic solid-brush rendering for each new blend mode without requiring unapproved golden images.
+    /// </summary>
+    [WebGPUTheory]
+    [WithBasicTestPatternImages(nameof(NewGraphicsOptionsModePairs), 384, 256, PixelTypes.Rgba32)]
+    public void NewBlendModes_SolidBrush_MatchDefaultOutput<TPixel>(
+        TestImageProvider<TPixel> provider,
+        PixelColorBlendingMode colorMode,
+        PixelAlphaCompositionMode alphaMode)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        RectanglePolygon polygon = new(26.5F, 18.25F, 324.5F, 208.75F);
+
+        // The scene transports brush colors as associated binary16, so the interior
+        // exactness assertion below requires source components that encoding holds
+        // losslessly; 0.2 is likewise exact in the 16-bit BlendPercentage encoding.
+        Brush brush = Brushes.Solid(Color.FromScaledVector(new Vector4(0.75F, 0.25F, 0.625F, 0.625F)));
+
+        DrawingOptions drawingOptions = new()
+        {
+            GraphicsOptions = new GraphicsOptions
+            {
+                Antialias = true,
+                BlendPercentage = 0.2F,
+                ColorBlendingMode = colorMode,
+                AlphaCompositionMode = alphaMode
+            }
+        };
+
+        void DrawAction(DrawingCanvas canvas) => canvas.Fill(brush, polygon);
+
+        using Image<TPixel> baseImage = provider.GetImage();
+        using Image<TPixel> defaultImage = baseImage.Clone();
+        RenderWithDefaultBackend(defaultImage, drawingOptions, DrawAction);
+
+        using WebGPUDrawingBackend backend = new();
+        using Image<TPixel> webGPUImage = RenderWithNativeSurfaceWebGpuBackend(
+            defaultImage.Width,
+            defaultImage.Height,
+            backend,
+            drawingOptions,
+            DrawAction,
+            baseImage);
+
+        DebugSaveBackendPair(provider, $"{colorMode}_{alphaMode}", defaultImage, webGPUImage);
+
+        // Antialiased edge coverage is tolerance-based between the backends, matching the
+        // established FillPath_WithGraphicsOptionsModes contract for identical scenes.
+        AssertBackendPairSimilarity(defaultImage, webGPUImage, 0.125F);
+
+        // Interior pixels carry full coverage on both backends, so the compositor itself
+        // must reproduce the CPU renderer exactly there.
+        AssertBackendPairSimilarityInRegion(defaultImage, webGPUImage, new Rectangle(28, 20, 294, 186), 0F);
+    }
+
+    /// <summary>
+    /// Verifies realistic image-brush rendering for each new blend mode without requiring unapproved golden images.
+    /// </summary>
+    [WebGPUTheory]
+    [WithBasicTestPatternImages(nameof(NewGraphicsOptionsModePairs), 384, 256, PixelTypes.Rgba32)]
+    public void NewBlendModes_ImageBrush_MatchDefaultOutput<TPixel>(
+        TestImageProvider<TPixel> provider,
+        PixelColorBlendingMode colorMode,
+        PixelAlphaCompositionMode alphaMode)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        RectanglePolygon polygon = new(26.5F, 18.25F, 324.5F, 208.75F);
+
+        DrawingOptions drawingOptions = new()
+        {
+            GraphicsOptions = new GraphicsOptions
+            {
+                Antialias = true,
+                BlendPercentage = 0.73F,
+                ColorBlendingMode = colorMode,
+                AlphaCompositionMode = alphaMode
+            }
+        };
+
+        using Image<TPixel> foreground = provider.GetImage();
+        Brush brush = new ImageBrush<TPixel>(foreground, new RectangleF(32, 24, 192, 144), new Point(13, -9));
+        void DrawAction(DrawingCanvas canvas) => canvas.Fill(brush, polygon);
+
+        using Image<TPixel> baseImage = provider.GetImage();
+        using Image<TPixel> defaultImage = baseImage.Clone();
+        RenderWithDefaultBackend(defaultImage, drawingOptions, DrawAction);
+
+        using WebGPUDrawingBackend backend = new();
+        using Image<TPixel> webGPUImage = RenderWithNativeSurfaceWebGpuBackend(
+            defaultImage.Width,
+            defaultImage.Height,
+            backend,
+            drawingOptions,
+            DrawAction,
+            baseImage);
+
+        DebugSaveBackendPair(provider, $"{colorMode}_{alphaMode}", defaultImage, webGPUImage);
+
+        // Antialiased edge coverage is tolerance-based between the backends, matching the
+        // established FillPath_WithGraphicsOptionsModes contract for identical scenes.
+        AssertBackendPairSimilarity(defaultImage, webGPUImage, 0.125F);
+
+        // Interior pixels carry full coverage on both backends, so the compositor itself
+        // must reproduce the CPU renderer exactly there.
+        AssertBackendPairSimilarityInRegion(defaultImage, webGPUImage, new Rectangle(28, 20, 294, 186), 0F);
+    }
+
+    /// <summary>
+    /// Verifies gradient-backed rendering for each new blend mode. Gradients take a separate
+    /// shader source path (ramp texture sampling with per-draw blend flags) that solid fills
+    /// never execute.
+    /// </summary>
+    /// <param name="colorMode">The color blend mode to test.</param>
+    /// <param name="alphaMode">The alpha composition mode to test.</param>
+    [WebGPUTheory]
+    [MemberData(nameof(NewGraphicsOptionsModePairs))]
+    public void NewBlendModes_LinearGradientBrush_MatchDefaultOutput(
+        PixelColorBlendingMode colorMode,
+        PixelAlphaCompositionMode alphaMode)
+    {
+        DrawingOptions drawingOptions = new()
+        {
+            GraphicsOptions = new GraphicsOptions
+            {
+                Antialias = false,
+                // 0.2 is exactly representable in the scene's 16-bit BlendPercentage encoding.
+                BlendPercentage = 0.2F,
+                ColorBlendingMode = colorMode,
+                AlphaCompositionMode = alphaMode
+            }
+        };
+
+        using Image<Rgba32> baseImage = new(96, 64, new Rgba32(42, 106, 181, 173));
+        using Image<Rgba32> defaultImage = baseImage.Clone();
+
+        // Identical stops make the ramp constant: the multi-color ramp's t-snapping noise
+        // is tolerance-based by the established gradient contract, and the nonlinear blend
+        // curves would amplify it past any fixed tolerance. A constant ramp keeps the full
+        // gradient shader path while permitting an exact comparison for every mode, and a
+        // byte-grid stop color survives the ramp's texel storage on both backends.
+        Color stopColor = Color.FromPixel(new Rgba32(218, 71, 133, 157));
+        Brush brush = new LinearGradientBrush(
+            new PointF(0, 0),
+            new PointF(96, 64),
+            GradientRepetitionMode.None,
+            new ColorStop(0, stopColor),
+            new ColorStop(1, stopColor));
+        RectanglePolygon rectangle = new(0, 0, 96, 64);
+
+        void DrawAction(DrawingCanvas canvas) => canvas.Fill(brush, rectangle);
+
+        RenderWithDefaultBackend(defaultImage, drawingOptions, DrawAction);
+
+        using WebGPUDrawingBackend backend = new();
+        using Image<Rgba32> webGPUImage = RenderWithNativeSurfaceWebGpuBackend(
+            defaultImage.Width,
+            defaultImage.Height,
+            backend,
+            drawingOptions,
+            DrawAction,
+            baseImage);
+
+        // A zero tolerance makes the CPU output the reference for every rendered pixel.
+        AssertBackendPairSimilarity(defaultImage, webGPUImage, 0F);
+    }
+
+    /// <summary>
+    /// Verifies the singular ColorDodge and ColorBurn branches with channel values that hit
+    /// every explicit branch on both backends, including their precedence order. Source
+    /// components are scaled values the binary16 scene encoding holds losslessly, so the
+    /// zero and one singular inputs reach both backends bit-identically.
+    /// </summary>
+    /// <param name="backdropR">The backdrop red component.</param>
+    /// <param name="backdropG">The backdrop green component.</param>
+    /// <param name="backdropB">The backdrop blue component.</param>
+    /// <param name="backdropA">The backdrop alpha component.</param>
+    /// <param name="sourceR">The scaled source red component.</param>
+    /// <param name="sourceG">The scaled source green component.</param>
+    /// <param name="sourceB">The scaled source blue component.</param>
+    /// <param name="sourceA">The scaled source alpha component.</param>
+    [WebGPUTheory]
+    [InlineData(0, 255, 128, 200, 1F, 0F, 0.78125F, 0.859375F)]
+    [InlineData(128, 200, 255, 173, 1F, 1F, 0F, 0.6875F)]
+    public void ColorDodgeAndColorBurn_WithSingularChannelValues_MatchDefaultOutput(
+        byte backdropR,
+        byte backdropG,
+        byte backdropB,
+        byte backdropA,
+        float sourceR,
+        float sourceG,
+        float sourceB,
+        float sourceA)
+    {
+        Rgba32 backdrop = new(backdropR, backdropG, backdropB, backdropA);
+        SolidBrush brush = Brushes.Solid(Color.FromScaledVector(new Vector4(sourceR, sourceG, sourceB, sourceA)));
+        RectanglePolygon rectangle = new(0, 0, 8, 8);
+        void DrawAction(DrawingCanvas canvas) => canvas.Fill(brush, rectangle);
+
+        foreach (PixelColorBlendingMode colorMode in new[] { PixelColorBlendingMode.ColorDodge, PixelColorBlendingMode.ColorBurn })
+        {
+            DrawingOptions drawingOptions = new()
+            {
+                GraphicsOptions = new GraphicsOptions
+                {
+                    Antialias = false,
+                    BlendPercentage = 0.2F,
+                    ColorBlendingMode = colorMode,
+                    AlphaCompositionMode = PixelAlphaCompositionMode.SrcOver
+                }
+            };
+
+            using Image<Rgba32> baseImage = new(8, 8, backdrop);
+            using Image<Rgba32> defaultImage = baseImage.Clone();
+            RenderWithDefaultBackend(defaultImage, drawingOptions, DrawAction);
+
+            using WebGPUDrawingBackend backend = new();
+            using Image<Rgba32> webGPUImage = RenderWithNativeSurfaceWebGpuBackend(
+                defaultImage.Width,
+                defaultImage.Height,
+                backend,
+                drawingOptions,
+                DrawAction,
+                baseImage);
+
+            // A zero tolerance makes the CPU output the reference for every rendered pixel.
+            AssertBackendPairSimilarity(defaultImage, webGPUImage, 0F);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Difference and Exclusion match the CPU renderer independently and produce
+    /// distinct results from each other for the same inputs.
+    /// </summary>
+    [WebGPUFact]
+    public void DifferenceAndExclusion_MatchDefaultOutputAndDiffer()
+    {
+        using Image<Rgba32> baseImage = new(8, 8, new Rgba32(42, 106, 181, 173));
+
+        // Wire-exact source components and BlendPercentage keep the exactness assertion
+        // within the binary16 scene transport contract.
+        SolidBrush brush = Brushes.Solid(Color.FromScaledVector(new Vector4(0.75F, 0.25F, 0.625F, 0.625F)));
+        RectanglePolygon rectangle = new(0, 0, 8, 8);
+        void DrawAction(DrawingCanvas canvas) => canvas.Fill(brush, rectangle);
+
+        Image<Rgba32> RenderPair(PixelColorBlendingMode colorMode)
+        {
+            DrawingOptions drawingOptions = new()
+            {
+                GraphicsOptions = new GraphicsOptions
+                {
+                    Antialias = false,
+                    BlendPercentage = 0.2F,
+                    ColorBlendingMode = colorMode,
+                    AlphaCompositionMode = PixelAlphaCompositionMode.SrcOver
+                }
+            };
+
+            Image<Rgba32> defaultImage = baseImage.Clone();
+            RenderWithDefaultBackend(defaultImage, drawingOptions, DrawAction);
+
+            using WebGPUDrawingBackend backend = new();
+            using Image<Rgba32> webGPUImage = RenderWithNativeSurfaceWebGpuBackend(
+                defaultImage.Width,
+                defaultImage.Height,
+                backend,
+                drawingOptions,
+                DrawAction,
+                baseImage);
+
+            // A zero tolerance makes the CPU output the reference for every rendered pixel.
+            AssertBackendPairSimilarity(defaultImage, webGPUImage, 0F);
+            return defaultImage;
+        }
+
+        using Image<Rgba32> difference = RenderPair(PixelColorBlendingMode.Difference);
+        using Image<Rgba32> exclusion = RenderPair(PixelColorBlendingMode.Exclusion);
+
+        // The chosen inputs separate |Cb - Cs| from Cb + Cs - 2CbCs, proving the two modes
+        // are implemented independently rather than aliased to one formula.
+        Assert.NotEqual(difference[4, 4], exclusion[4, 4]);
+    }
+
+    /// <summary>
+    /// Verifies transparent-backdrop and zero-alpha-source inputs for each new blend mode.
+    /// </summary>
+    /// <param name="colorMode">The color blend mode to test.</param>
+    /// <param name="alphaMode">The alpha composition mode to test.</param>
+    [WebGPUTheory]
+    [MemberData(nameof(NewGraphicsOptionsModePairs))]
+    public void NewBlendModes_TransparentAndZeroAlphaInputs_MatchDefaultOutput(
+        PixelColorBlendingMode colorMode,
+        PixelAlphaCompositionMode alphaMode)
+    {
+        DrawingOptions drawingOptions = new()
+        {
+            GraphicsOptions = new GraphicsOptions
+            {
+                Antialias = false,
+                BlendPercentage = 0.73F,
+                ColorBlendingMode = colorMode,
+                AlphaCompositionMode = alphaMode
+            }
+        };
+
+        RectanglePolygon rectangle = new(0, 0, 8, 8);
+
+        void AssertScenario(Rgba32 backdrop, Rgba32 source)
+        {
+            SolidBrush brush = Brushes.Solid(Color.FromPixel(source));
+            void DrawAction(DrawingCanvas canvas) => canvas.Fill(brush, rectangle);
+
+            using Image<Rgba32> baseImage = new(8, 8, backdrop);
+            using Image<Rgba32> defaultImage = baseImage.Clone();
+            RenderWithDefaultBackend(defaultImage, drawingOptions, DrawAction);
+
+            using WebGPUDrawingBackend backend = new();
+            using Image<Rgba32> webGPUImage = RenderWithNativeSurfaceWebGpuBackend(
+                defaultImage.Width,
+                defaultImage.Height,
+                backend,
+                drawingOptions,
+                DrawAction,
+                baseImage);
+
+            // A zero tolerance makes the CPU output the reference for every rendered pixel.
+            AssertBackendPairSimilarity(defaultImage, webGPUImage, 0F);
+        }
+
+        // Transparent black backdrop: the composed result must come from the source alone.
+        AssertScenario(new Rgba32(0, 0, 0, 0), new Rgba32(218, 71, 133, 157));
+
+        // Zero-alpha source: source-over and plus must leave the backdrop untouched.
+        AssertScenario(new Rgba32(42, 106, 181, 173), new Rgba32(218, 71, 133, 0));
+    }
+
+    /// <summary>
+    /// Creates the complete cross-product used to exercise composition independently of color blending.
+    /// </summary>
+    /// <returns>The color blend and alpha composition mode pairs.</returns>
+    private static TheoryData<PixelColorBlendingMode, PixelAlphaCompositionMode> CreateNewColorBlendCompositionPairs()
+    {
+        PixelColorBlendingMode[] colorModes =
+        [
+            PixelColorBlendingMode.ColorDodge,
+            PixelColorBlendingMode.ColorBurn,
+            PixelColorBlendingMode.SoftLight,
+            PixelColorBlendingMode.Difference,
+            PixelColorBlendingMode.Exclusion,
+            PixelColorBlendingMode.Hue,
+            PixelColorBlendingMode.Saturation,
+            PixelColorBlendingMode.Color,
+            PixelColorBlendingMode.Luminosity
+        ];
+
+        TheoryData<PixelColorBlendingMode, PixelAlphaCompositionMode> pairs = new();
+        foreach (PixelColorBlendingMode colorMode in colorModes)
+        {
+            foreach (PixelAlphaCompositionMode alphaMode in Enum.GetValues<PixelAlphaCompositionMode>())
+            {
+                pairs.Add(colorMode, alphaMode);
+            }
+        }
+
+        return pairs;
+    }
+}

--- a/tests/ImageSharp.Drawing.Tests/Processing/RichTextGlyphRendererTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Processing/RichTextGlyphRendererTests.cs
@@ -1,10 +1,14 @@
 // Copyright (c) Six Labors.
 // Licensed under the Six Labors Split License.
 
+using System.Numerics;
 using SixLabors.Fonts;
 using SixLabors.Fonts.Rendering;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Drawing.Processing.Processors.Text;
+using SixLabors.ImageSharp.Drawing.Tests.TestUtilities.ImageComparison;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 
 namespace SixLabors.ImageSharp.Drawing.Tests.Processing;
 
@@ -67,6 +71,212 @@ public class RichTextGlyphRendererTests
         // offset path must reproduce both components of the fresh operation's device position.
         Assert.Equal(fresh.RenderLocation, cached.RenderLocation);
         Assert.Equal(fresh.SubPixelOffset, cached.SubPixelOffset);
+    }
+
+    /// <summary>
+    /// Verifies that nested COLR v1 composite groups are lowered to isolated drawing operations.
+    /// </summary>
+    [Fact]
+    public void RenderGlyph_NestedColrV1Composite_EmitsIsolatedGroups()
+    {
+        Font font = TestFontUtilities.GetFont(TestFonts.NotoColorEmojiRegular, 128);
+        RichGlyphOptions glyphOptions = new()
+        {
+            Font = font,
+            ColorFontSupport = ColorFontSupport.ColrV1
+        };
+
+        List<DrawingOperation> operations = [];
+        using RichTextGlyphRenderer renderer = new(
+            new DrawingOptions(),
+            path: null,
+            pen: null,
+            brush: Brushes.Solid(Color.Black),
+            new DrawingTextCache(),
+            operations);
+
+        // This glyph is a SoftLight composite whose source is a nested SrcIn composite, and
+        // the inner source is a linear gradient with no outline. Each composite lowers to one
+        // isolating group holding a backdrop group and a source group, and the source group
+        // carries the composite mode. The gradient arrives as an ordinary layer whose figure
+        // is the clip bounds or the glyph bounds.
+        TextRenderer.RenderTo(renderer, 2629, glyphOptions);
+
+        Assert.Equal(
+        [
+            DrawingOperationKind.BeginGroup,
+            DrawingOperationKind.BeginGroup,
+            DrawingOperationKind.Fill,
+            DrawingOperationKind.Fill,
+            DrawingOperationKind.Fill,
+            DrawingOperationKind.EndGroup,
+            DrawingOperationKind.BeginGroup,
+            DrawingOperationKind.BeginGroup,
+            DrawingOperationKind.BeginGroup,
+            DrawingOperationKind.Fill,
+            DrawingOperationKind.Fill,
+            DrawingOperationKind.Fill,
+            DrawingOperationKind.EndGroup,
+            DrawingOperationKind.BeginGroup,
+            DrawingOperationKind.Fill,
+            DrawingOperationKind.EndGroup,
+            DrawingOperationKind.EndGroup,
+            DrawingOperationKind.EndGroup,
+            DrawingOperationKind.EndGroup
+        ],
+        operations.Select(x => x.Kind));
+
+        Assert.True(operations[0].ApplyDrawingOptions);
+        Assert.False(operations[1].ApplyDrawingOptions);
+        Assert.Equal(PixelColorBlendingMode.SoftLight, operations[6].PixelColorBlendingMode);
+        Assert.Equal(PixelAlphaCompositionMode.SrcOver, operations[6].PixelAlphaCompositionMode);
+        Assert.Equal(PixelColorBlendingMode.Normal, operations[13].PixelColorBlendingMode);
+        Assert.Equal(PixelAlphaCompositionMode.SrcIn, operations[13].PixelAlphaCompositionMode);
+        Assert.IsType<LinearGradientBrush>(operations[14].Brush);
+        Assert.False(operations[14].Path!.Bounds.IsEmpty);
+    }
+
+    /// <summary>
+    /// Verifies that caller opacity is applied to the completed COLR v1 composite rather than to each paint leaf.
+    /// </summary>
+    [Fact]
+    public void DrawGlyph_NestedColrV1Composite_AppliesCallerOpacityOnce()
+    {
+        Font font = TestFontUtilities.GetFont(TestFonts.NotoColorEmojiRegular, 128);
+        RichGlyphOptions glyphOptions = new()
+        {
+            Font = font,
+            Origin = new Vector2(16, 16),
+            ColorFontSupport = ColorFontSupport.ColrV1
+        };
+
+        using Image<Rgba32> fullOpacity = new(192, 192);
+        fullOpacity.Mutate(context => context.Paint(
+            new DrawingOptions(),
+            canvas => canvas.DrawText(2629, glyphOptions, Brushes.Solid(Color.Black), pen: null)));
+
+        DrawingOptions halfOpacityOptions = new()
+        {
+            GraphicsOptions = new GraphicsOptions { BlendPercentage = .5F }
+        };
+
+        using Image<Rgba32> halfOpacity = new(192, 192);
+        halfOpacity.Mutate(context => context.Paint(
+            halfOpacityOptions,
+            canvas => canvas.DrawText(2629, glyphOptions, Brushes.Solid(Color.Black), pen: null)));
+
+        Rgba32 fullPixel = fullOpacity[96, 96];
+        Rgba32 halfPixel = halfOpacity[96, 96];
+
+        Assert.NotEqual(0, fullPixel.A);
+        Assert.InRange(Math.Abs(halfPixel.R - fullPixel.R), 0, 1);
+        Assert.InRange(Math.Abs(halfPixel.G - fullPixel.G), 0, 1);
+        Assert.InRange(Math.Abs(halfPixel.B - fullPixel.B), 0, 1);
+        Assert.InRange(Math.Abs(halfPixel.A - (fullPixel.A * .5F)), 0F, 1F);
+    }
+
+    /// <summary>
+    /// Verifies that a layered COLR v1 cache hit replays the full operation sequence with no
+    /// callbacks: kinds, positions, bounds, and modes match the fresh render, and outlined
+    /// layer paths are the identical cached instances rather than rebuilt geometry.
+    /// </summary>
+    [Fact]
+    public void RenderGlyph_LayeredColrV1CacheHit_ReplaysFreshOperationSequence()
+    {
+        Font font = TestFontUtilities.GetFont(TestFonts.NotoColorEmojiRegular, 128);
+        RichGlyphOptions glyphOptions = new()
+        {
+            Font = font,
+            Origin = new Vector2(16.5F, 16.25F),
+            ColorFontSupport = ColorFontSupport.ColrV1
+        };
+
+        DrawingTextCache cache = new();
+        List<DrawingOperation> fresh = [];
+        using RichTextGlyphRenderer freshRenderer = new(
+            new DrawingOptions(),
+            path: null,
+            pen: null,
+            brush: Brushes.Solid(Color.Black),
+            cache,
+            fresh);
+        TextRenderer.RenderTo(freshRenderer, 2629, glyphOptions);
+
+        List<DrawingOperation> cached = [];
+        using RichTextGlyphRenderer cachedRenderer = new(
+            new DrawingOptions(),
+            path: null,
+            pen: null,
+            brush: Brushes.Solid(Color.Black),
+            cache,
+            cached);
+        TextRenderer.RenderTo(cachedRenderer, 2629, glyphOptions);
+
+        Assert.NotEmpty(fresh);
+        Assert.Equal(fresh.Count, cached.Count);
+        for (int i = 0; i < fresh.Count; i++)
+        {
+            DrawingOperation expected = fresh[i];
+            DrawingOperation actual = cached[i];
+            Assert.Equal(expected.Kind, actual.Kind);
+            Assert.Equal(expected.RenderLocation, actual.RenderLocation);
+            Assert.Equal(expected.SubPixelOffset, actual.SubPixelOffset);
+            Assert.Equal(expected.CompositeBounds, actual.CompositeBounds);
+            Assert.Equal(expected.ApplyDrawingOptions, actual.ApplyDrawingOptions);
+            Assert.Equal(expected.GlyphClip, actual.GlyphClip);
+            Assert.Equal(expected.IntersectionRule, actual.IntersectionRule);
+            Assert.Equal(expected.PixelAlphaCompositionMode, actual.PixelAlphaCompositionMode);
+            Assert.Equal(expected.PixelColorBlendingMode, actual.PixelColorBlendingMode);
+            Assert.Equal(expected.Brush?.GetType(), actual.Brush?.GetType());
+
+            if (expected.HasGlyphKey && expected.Path is not null)
+            {
+                // Outlined layers must reuse the identical cached path instance.
+                Assert.Same(expected.Path, actual.Path);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a layered COLR v1 cache hit renders pixel-identical output. The same
+    /// glyph draws twice through one shared canvas cache, and the replayed second glyph must
+    /// match a fresh render at that position exactly.
+    /// </summary>
+    [Fact]
+    public void DrawGlyph_LayeredColrV1CacheHit_MatchesFreshOutput()
+    {
+        Font font = TestFontUtilities.GetFont(TestFonts.NotoColorEmojiRegular, 128);
+        RichGlyphOptions firstOptions = new()
+        {
+            Font = font,
+            Origin = new Vector2(16.5F, 16.25F),
+            ColorFontSupport = ColorFontSupport.ColrV1
+        };
+
+        // An integer-only origin delta keeps the replay's anchor math bit-identical to a
+        // fresh render, so the replayed glyph must match to the pixel.
+        RichGlyphOptions secondOptions = new()
+        {
+            Font = font,
+            Origin = new Vector2(16.5F, 200.25F),
+            ColorFontSupport = ColorFontSupport.ColrV1
+        };
+
+        using Image<Rgba32> doubleDraw = new(192, 384);
+        doubleDraw.Mutate(context => context.Paint(new DrawingOptions(), canvas =>
+        {
+            canvas.DrawText(2629, firstOptions, Brushes.Solid(Color.Black), pen: null);
+            canvas.DrawText(2629, secondOptions, Brushes.Solid(Color.Black), pen: null);
+        }));
+
+        using Image<Rgba32> freshDraw = new(192, 384);
+        freshDraw.Mutate(context => context.Paint(
+            new DrawingOptions(),
+            canvas => canvas.DrawText(2629, secondOptions, Brushes.Solid(Color.Black), pen: null)));
+
+        using Image<Rgba32> actualRegion = doubleDraw.Clone(context => context.Crop(new Rectangle(0, 184, 192, 200)));
+        using Image<Rgba32> expectedRegion = freshDraw.Clone(context => context.Crop(new Rectangle(0, 184, 192, 200)));
+        ImageComparer.Exact.VerifySimilarity(expectedRegion, actualRegion);
     }
 
     private static int CountOperations(Font font, string text, List<RichTextRun>? runs)

--- a/tests/ImageSharp.Drawing.Tests/Shapes/TextBuilderTests.cs
+++ b/tests/ImageSharp.Drawing.Tests/Shapes/TextBuilderTests.cs
@@ -177,20 +177,28 @@ public class TextBuilderTests
     [InlineData(CompositeMode.SrcAtop, PixelAlphaCompositionMode.SrcAtop)]
     [InlineData(CompositeMode.DestAtop, PixelAlphaCompositionMode.DestAtop)]
     [InlineData(CompositeMode.Xor, PixelAlphaCompositionMode.Xor)]
+    [InlineData(CompositeMode.Plus, PixelAlphaCompositionMode.Plus)]
     [InlineData(CompositeMode.Multiply, PixelAlphaCompositionMode.SrcOver)]
     public void TextUtilities_MapsAlphaCompositionModes(CompositeMode compositeMode, PixelAlphaCompositionMode alphaCompositionMode)
         => Assert.Equal(alphaCompositionMode, TextUtilities.MapCompositionMode(compositeMode));
 
     [Theory]
-    [InlineData(CompositeMode.Plus, PixelColorBlendingMode.Add)]
     [InlineData(CompositeMode.Screen, PixelColorBlendingMode.Screen)]
     [InlineData(CompositeMode.Overlay, PixelColorBlendingMode.Overlay)]
     [InlineData(CompositeMode.Darken, PixelColorBlendingMode.Darken)]
     [InlineData(CompositeMode.Lighten, PixelColorBlendingMode.Lighten)]
     [InlineData(CompositeMode.HardLight, PixelColorBlendingMode.HardLight)]
     [InlineData(CompositeMode.Multiply, PixelColorBlendingMode.Multiply)]
+    [InlineData(CompositeMode.ColorDodge, PixelColorBlendingMode.ColorDodge)]
+    [InlineData(CompositeMode.ColorBurn, PixelColorBlendingMode.ColorBurn)]
+    [InlineData(CompositeMode.SoftLight, PixelColorBlendingMode.SoftLight)]
+    [InlineData(CompositeMode.Difference, PixelColorBlendingMode.Difference)]
+    [InlineData(CompositeMode.Exclusion, PixelColorBlendingMode.Exclusion)]
+    [InlineData(CompositeMode.Hue, PixelColorBlendingMode.Hue)]
+    [InlineData(CompositeMode.Saturation, PixelColorBlendingMode.Saturation)]
+    [InlineData(CompositeMode.Color, PixelColorBlendingMode.Color)]
+    [InlineData(CompositeMode.Luminosity, PixelColorBlendingMode.Luminosity)]
     [InlineData(CompositeMode.SrcOver, PixelColorBlendingMode.Normal)]
-    [InlineData(CompositeMode.ColorDodge, PixelColorBlendingMode.Normal)]
     public void TextUtilities_MapsColorBlendingModes(CompositeMode compositeMode, PixelColorBlendingMode colorBlendingMode)
         => Assert.Equal(colorBlendingMode, TextUtilities.MapBlendingMode(compositeMode));
 

--- a/tests/ImageSharp.Drawing.Tests/TestUtilities/TestMemoryAllocator.cs
+++ b/tests/ImageSharp.Drawing.Tests/TestUtilities/TestMemoryAllocator.cs
@@ -12,6 +12,8 @@ internal class TestMemoryAllocator : MemoryAllocator
 {
     private readonly List<AllocationRequest> allocationLog = [];
     private readonly List<ReturnRequest> returnLog = [];
+    private readonly object allocationLogSync = new();
+    private readonly object returnLogSync = new();
 
     public TestMemoryAllocator(byte dirtyValue = 42) => this.DirtyValue = dirtyValue;
 
@@ -22,9 +24,31 @@ internal class TestMemoryAllocator : MemoryAllocator
 
     public int BufferCapacityInBytes { get; set; } = int.MaxValue;
 
-    public IReadOnlyList<AllocationRequest> AllocationLog => this.allocationLog;
+    public IReadOnlyList<AllocationRequest> AllocationLog
+    {
+        get
+        {
+            // Snapshot under the writer lock: parallel workers can still append while a
+            // test enumerates, and List<T> enumeration is not safe against concurrent Add.
+            lock (this.allocationLogSync)
+            {
+                return [.. this.allocationLog];
+            }
+        }
+    }
 
-    public IReadOnlyList<ReturnRequest> ReturnLog => this.returnLog;
+    public IReadOnlyList<ReturnRequest> ReturnLog
+    {
+        get
+        {
+            // Snapshot under the writer lock: the finalizer thread can still append
+            // returns while a test enumerates the log.
+            lock (this.returnLogSync)
+            {
+                return [.. this.returnLog];
+            }
+        }
+    }
 
     protected internal override int GetBufferCapacityInBytes() => this.BufferCapacityInBytes;
 
@@ -38,7 +62,13 @@ internal class TestMemoryAllocator : MemoryAllocator
         where T : struct
     {
         T[] array = new T[length + 42];
-        this.allocationLog.Add(AllocationRequest.Create(options, length, array));
+
+        // Image processors can request buffers from parallel workers. Serialize the test log
+        // mutation so its observed allocation count cannot lose or corrupt concurrent entries.
+        lock (this.allocationLogSync)
+        {
+            this.allocationLog.Add(AllocationRequest.Create(options, length, array));
+        }
 
         if (options == AllocationOptions.None)
         {
@@ -50,7 +80,15 @@ internal class TestMemoryAllocator : MemoryAllocator
     }
 
     private void Return<T>(BasicArrayBuffer<T> buffer)
-        where T : struct => this.returnLog.Add(new ReturnRequest(buffer.Array.GetHashCode()));
+        where T : struct
+    {
+        // Returns can arrive from worker or finalizer threads, so they require the same
+        // serialized logging contract as allocations.
+        lock (this.returnLogSync)
+        {
+            this.returnLog.Add(new ReturnRequest(buffer.Array.GetHashCode()));
+        }
+    }
 
     public struct AllocationRequest
     {

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c37fafab2ab35b0307bf336a8b303be9b9f5799ebf82a098fa61fecb30b2aa
+size 115

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c37fafab2ab35b0307bf336a8b303be9b9f5799ebf82a098fa61fecb30b2aa
+size 115

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c37fafab2ab35b0307bf336a8b303be9b9f5799ebf82a098fa61fecb30b2aa
+size 115

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c37fafab2ab35b0307bf336a8b303be9b9f5799ebf82a098fa61fecb30b2aa
+size 115

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c37fafab2ab35b0307bf336a8b303be9b9f5799ebf82a098fa61fecb30b2aa
+size 115

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c37fafab2ab35b0307bf336a8b303be9b9f5799ebf82a098fa61fecb30b2aa
+size 115

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c37fafab2ab35b0307bf336a8b303be9b9f5799ebf82a098fa61fecb30b2aa
+size 115

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c37fafab2ab35b0307bf336a8b303be9b9f5799ebf82a098fa61fecb30b2aa
+size 115

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Clear_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c37fafab2ab35b0307bf336a8b303be9b9f5799ebf82a098fa61fecb30b2aa
+size 115

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f78eef074d4534038ade97aea1dd9f305fb5d6a10d3f2ed1ee2a41751d13da4d
+size 1222

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f78eef074d4534038ade97aea1dd9f305fb5d6a10d3f2ed1ee2a41751d13da4d
+size 1222

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7dea02c18cc6167ff900136ff3bbedc7c27ad318ca5dc0da9d30239b7986298
+size 1222

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestAtop_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:099362534931cb6f4577bb1481efda1ff70be4f2e0db19d920ef6bd769f72078
+size 1285

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:099362534931cb6f4577bb1481efda1ff70be4f2e0db19d920ef6bd769f72078
+size 1285

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:099362534931cb6f4577bb1481efda1ff70be4f2e0db19d920ef6bd769f72078
+size 1285

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:099362534931cb6f4577bb1481efda1ff70be4f2e0db19d920ef6bd769f72078
+size 1285

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:099362534931cb6f4577bb1481efda1ff70be4f2e0db19d920ef6bd769f72078
+size 1285

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:099362534931cb6f4577bb1481efda1ff70be4f2e0db19d920ef6bd769f72078
+size 1285

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:099362534931cb6f4577bb1481efda1ff70be4f2e0db19d920ef6bd769f72078
+size 1285

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:099362534931cb6f4577bb1481efda1ff70be4f2e0db19d920ef6bd769f72078
+size 1285

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestIn_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:099362534931cb6f4577bb1481efda1ff70be4f2e0db19d920ef6bd769f72078
+size 1285

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOut_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bc5674d00637b4aa3d021e3394fc2908999da88bbaeea5262f9e6c91906c77
+size 1174

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bc5674d00637b4aa3d021e3394fc2908999da88bbaeea5262f9e6c91906c77
+size 1174

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bc5674d00637b4aa3d021e3394fc2908999da88bbaeea5262f9e6c91906c77
+size 1174

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea0ec0ec7608f16f0b1202aa67365c3771843cbf23dc162b287f5800a89314b
+size 922

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea0ec0ec7608f16f0b1202aa67365c3771843cbf23dc162b287f5800a89314b
+size 922

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bc5674d00637b4aa3d021e3394fc2908999da88bbaeea5262f9e6c91906c77
+size 1174

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65e949ab6318010b0a441a41c84d6f06be435c30e00ada27e63f92a10c6d7dca
+size 1155

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bc5674d00637b4aa3d021e3394fc2908999da88bbaeea5262f9e6c91906c77
+size 1174

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-DestOver_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bc5674d00637b4aa3d021e3394fc2908999da88bbaeea5262f9e6c91906c77
+size 1174

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Dest_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Add.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Add.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:543b1e0a5fe32cecf0ef4e79924e3932c849fb509878a9b8eb33fc6ee3007df4
+size 1124

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9431a91d94c6e53ed336ad979afa85cf9f86f6c85c91249ef6eb8724285682f
+size 1090

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea0ec0ec7608f16f0b1202aa67365c3771843cbf23dc162b287f5800a89314b
+size 922

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:543b1e0a5fe32cecf0ef4e79924e3932c849fb509878a9b8eb33fc6ee3007df4
+size 1124

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Darken.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Darken.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea0ec0ec7608f16f0b1202aa67365c3771843cbf23dc162b287f5800a89314b
+size 922

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:543b1e0a5fe32cecf0ef4e79924e3932c849fb509878a9b8eb33fc6ee3007df4
+size 1124

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:543b1e0a5fe32cecf0ef4e79924e3932c849fb509878a9b8eb33fc6ee3007df4
+size 1124

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-HardLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-HardLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea0ec0ec7608f16f0b1202aa67365c3771843cbf23dc162b287f5800a89314b
+size 922

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9431a91d94c6e53ed336ad979afa85cf9f86f6c85c91249ef6eb8724285682f
+size 1090

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Lighten.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Lighten.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:543b1e0a5fe32cecf0ef4e79924e3932c849fb509878a9b8eb33fc6ee3007df4
+size 1124

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea0ec0ec7608f16f0b1202aa67365c3771843cbf23dc162b287f5800a89314b
+size 922

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Multiply.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Multiply.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea0ec0ec7608f16f0b1202aa67365c3771843cbf23dc162b287f5800a89314b
+size 922

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Normal.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea0ec0ec7608f16f0b1202aa67365c3771843cbf23dc162b287f5800a89314b
+size 922

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Overlay.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Overlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:523a79a2f31e978d43bd62ad3355b7310489c50dd6f3789d16dd2b17eb994d7e
+size 1103

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9431a91d94c6e53ed336ad979afa85cf9f86f6c85c91249ef6eb8724285682f
+size 1090

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Screen.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:543b1e0a5fe32cecf0ef4e79924e3932c849fb509878a9b8eb33fc6ee3007df4
+size 1124

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39d2fd147be17b70e933d517a42d25e6ef21d53369e1eeea1d628af83ade25b9
+size 1161

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Subtract.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Plus_blending-Subtract.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:543b1e0a5fe32cecf0ef4e79924e3932c849fb509878a9b8eb33fc6ee3007df4
+size 1124

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:891510c4d856f18568da2543e17e0e43e833cc23047b21b150053a3aa222a094
+size 1354

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42385c7205f76271551ef3524130aa4de54ec68e62c0887e2dd96ca001d6898f
+size 1261

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:891510c4d856f18568da2543e17e0e43e833cc23047b21b150053a3aa222a094
+size 1354

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42385c7205f76271551ef3524130aa4de54ec68e62c0887e2dd96ca001d6898f
+size 1261

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:891510c4d856f18568da2543e17e0e43e833cc23047b21b150053a3aa222a094
+size 1354

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcAtop_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97709a66a278eed4be43e61be8668c29c8f39310d5790485ec272bfe6c761a48
+size 1193

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8d6ce61d5bfb3f6ca7523af7e9179d1195a9715f7c69a8d05087f4af5d26e0
+size 490

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8d6ce61d5bfb3f6ca7523af7e9179d1195a9715f7c69a8d05087f4af5d26e0
+size 490

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8d6ce61d5bfb3f6ca7523af7e9179d1195a9715f7c69a8d05087f4af5d26e0
+size 490

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8d6ce61d5bfb3f6ca7523af7e9179d1195a9715f7c69a8d05087f4af5d26e0
+size 490

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8d6ce61d5bfb3f6ca7523af7e9179d1195a9715f7c69a8d05087f4af5d26e0
+size 490

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8d6ce61d5bfb3f6ca7523af7e9179d1195a9715f7c69a8d05087f4af5d26e0
+size 490

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8d6ce61d5bfb3f6ca7523af7e9179d1195a9715f7c69a8d05087f4af5d26e0
+size 490

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8d6ce61d5bfb3f6ca7523af7e9179d1195a9715f7c69a8d05087f4af5d26e0
+size 490

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcIn_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c8d6ce61d5bfb3f6ca7523af7e9179d1195a9715f7c69a8d05087f4af5d26e0
+size 490

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8047ea8412a1d53f4a560a6c08afb0b77686058515d9225021ffe506ddfddfcf
+size 875

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8047ea8412a1d53f4a560a6c08afb0b77686058515d9225021ffe506ddfddfcf
+size 875

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8047ea8412a1d53f4a560a6c08afb0b77686058515d9225021ffe506ddfddfcf
+size 875

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8047ea8412a1d53f4a560a6c08afb0b77686058515d9225021ffe506ddfddfcf
+size 875

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8047ea8412a1d53f4a560a6c08afb0b77686058515d9225021ffe506ddfddfcf
+size 875

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8047ea8412a1d53f4a560a6c08afb0b77686058515d9225021ffe506ddfddfcf
+size 875

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8047ea8412a1d53f4a560a6c08afb0b77686058515d9225021ffe506ddfddfcf
+size 875

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8047ea8412a1d53f4a560a6c08afb0b77686058515d9225021ffe506ddfddfcf
+size 875

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOut_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8047ea8412a1d53f4a560a6c08afb0b77686058515d9225021ffe506ddfddfcf
+size 875

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65e949ab6318010b0a441a41c84d6f06be435c30e00ada27e63f92a10c6d7dca
+size 1155

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bc5674d00637b4aa3d021e3394fc2908999da88bbaeea5262f9e6c91906c77
+size 1174

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea0ec0ec7608f16f0b1202aa67365c3771843cbf23dc162b287f5800a89314b
+size 922

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea0ec0ec7608f16f0b1202aa67365c3771843cbf23dc162b287f5800a89314b
+size 922

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ea0ec0ec7608f16f0b1202aa67365c3771843cbf23dc162b287f5800a89314b
+size 922

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65e949ab6318010b0a441a41c84d6f06be435c30e00ada27e63f92a10c6d7dca
+size 1155

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bc5674d00637b4aa3d021e3394fc2908999da88bbaeea5262f9e6c91906c77
+size 1174

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65e949ab6318010b0a441a41c84d6f06be435c30e00ada27e63f92a10c6d7dca
+size 1155

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-SrcOver_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8093822580287680ff47e7b045a8054d1da5721faeff2978e60041ad71621c4f
+size 1136

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Src_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a56bb51149625c546e19df6e42cbf59aef0a1a8dce2ba685e871972f8ccfb98
+size 1071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7485527fb00d711f171de19a3386a6cda0b8b7b0acf958ebc55078c5b219c3e
+size 1223

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7485527fb00d711f171de19a3386a6cda0b8b7b0acf958ebc55078c5b219c3e
+size 1223

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7485527fb00d711f171de19a3386a6cda0b8b7b0acf958ebc55078c5b219c3e
+size 1223

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7485527fb00d711f171de19a3386a6cda0b8b7b0acf958ebc55078c5b219c3e
+size 1223

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7485527fb00d711f171de19a3386a6cda0b8b7b0acf958ebc55078c5b219c3e
+size 1223

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7485527fb00d711f171de19a3386a6cda0b8b7b0acf958ebc55078c5b219c3e
+size 1223

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7485527fb00d711f171de19a3386a6cda0b8b7b0acf958ebc55078c5b219c3e
+size 1223

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7485527fb00d711f171de19a3386a6cda0b8b7b0acf958ebc55078c5b219c3e
+size 1223

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendBlackEllipse_composition-Xor_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7485527fb00d711f171de19a3386a6cda0b8b7b0acf958ebc55078c5b219c3e
+size 1223

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c0c2bf0974e0b16c752b4f2333fac027fb17aacf8e977af1615ac55981163a
+size 1281

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c0c2bf0974e0b16c752b4f2333fac027fb17aacf8e977af1615ac55981163a
+size 1281

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c0c2bf0974e0b16c752b4f2333fac027fb17aacf8e977af1615ac55981163a
+size 1281

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c0c2bf0974e0b16c752b4f2333fac027fb17aacf8e977af1615ac55981163a
+size 1281

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c0c2bf0974e0b16c752b4f2333fac027fb17aacf8e977af1615ac55981163a
+size 1281

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c0c2bf0974e0b16c752b4f2333fac027fb17aacf8e977af1615ac55981163a
+size 1281

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c0c2bf0974e0b16c752b4f2333fac027fb17aacf8e977af1615ac55981163a
+size 1281

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c0c2bf0974e0b16c752b4f2333fac027fb17aacf8e977af1615ac55981163a
+size 1281

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Clear_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c0c2bf0974e0b16c752b4f2333fac027fb17aacf8e977af1615ac55981163a
+size 1281

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3472f6a10d21fab345ca8460fa59a8ea1941b5221e9565b0a286cb70103eb10f
+size 3199

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72492357069420d64df28aadc31b7a87e70f5b1059b3cfa4889430580127622a
+size 3116

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2690f585664abb60ef0175b318ac9a83f3bb4ae64af45f367d44cd01fe468d61
+size 3185

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22e0e7eb580be93043384c64280cfe8249097a4c445bb2d9c2b4cd8b665e4cd3
+size 3005

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db249a11c77c0be2d6db68679c6a4307a89173fd176b5886f0b2f28a50b13982
+size 3005

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6774d06e938f7e06e8621fb8fa2eb445cd0db89eb4733ea2dbdedef385f8d1e8
+size 3267

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59658c9cc4f3ffba897b7375af202a26dde40cf13bcd02672b2edd51b190a806
+size 3071

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50ce69c16a0c6976abc1fea0129fee7ac4349bf97460c5db0d7537a46d80bce5
+size 3331

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestAtop_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfb8eb363641e82921a34622cde2bff1226f9aca17c1f9d8204339890fa7bc61
+size 3176

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027955f1a7dba21d02f785c23000fc15df4d09cc595d39c43e22271837f5f652
+size 1528

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027955f1a7dba21d02f785c23000fc15df4d09cc595d39c43e22271837f5f652
+size 1528

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027955f1a7dba21d02f785c23000fc15df4d09cc595d39c43e22271837f5f652
+size 1528

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027955f1a7dba21d02f785c23000fc15df4d09cc595d39c43e22271837f5f652
+size 1528

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027955f1a7dba21d02f785c23000fc15df4d09cc595d39c43e22271837f5f652
+size 1528

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027955f1a7dba21d02f785c23000fc15df4d09cc595d39c43e22271837f5f652
+size 1528

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027955f1a7dba21d02f785c23000fc15df4d09cc595d39c43e22271837f5f652
+size 1528

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027955f1a7dba21d02f785c23000fc15df4d09cc595d39c43e22271837f5f652
+size 1528

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestIn_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:027955f1a7dba21d02f785c23000fc15df4d09cc595d39c43e22271837f5f652
+size 1528

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed5aaa72ef7f0dba45be0056e87d818a0125b6327a2b65749e55a041f518119
+size 1224

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed5aaa72ef7f0dba45be0056e87d818a0125b6327a2b65749e55a041f518119
+size 1224

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed5aaa72ef7f0dba45be0056e87d818a0125b6327a2b65749e55a041f518119
+size 1224

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed5aaa72ef7f0dba45be0056e87d818a0125b6327a2b65749e55a041f518119
+size 1224

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed5aaa72ef7f0dba45be0056e87d818a0125b6327a2b65749e55a041f518119
+size 1224

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed5aaa72ef7f0dba45be0056e87d818a0125b6327a2b65749e55a041f518119
+size 1224

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed5aaa72ef7f0dba45be0056e87d818a0125b6327a2b65749e55a041f518119
+size 1224

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed5aaa72ef7f0dba45be0056e87d818a0125b6327a2b65749e55a041f518119
+size 1224

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOut_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ed5aaa72ef7f0dba45be0056e87d818a0125b6327a2b65749e55a041f518119
+size 1224

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff7c7dfa8f5819e5ac37277dbeae33729b3abe4437f2da88b1ffff505d5f6920
+size 2759

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:727e702c1fb388251a3e8e40989907583e6506a2776c151c7c018fa26f4c28e6
+size 2811

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b88280362914a0a3e3e6582db4036f7e6f5b4e305e7c759c5059e464afa62e06
+size 2872

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef3fac8bb5c05f161f3f736847cc648084bd5a4fa651db81bbb056b9b85eae49
+size 2636

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:859f3e49de6e7d613f4932e88ce0163f0771c932a4a6d91f7dde97528d5ed7ad
+size 2638

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:030eee591b617d080ed18b3899603d8d326a0f1eb5e2b746ec04d9e2ccbdaad1
+size 2853

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3c8853a6c4aac6b87aaa99919a6d05c034286a2827bd75dcb9915e55415a9ec
+size 2671

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:166928b4955d356951e65e240092d042829fdaa442675942f12fda1ca2c0a408
+size 2989

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-DestOver_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cb9ba6c23a22deb135f6fd724f6d6dd5b35b5c2433d81efec6f5b16925160e2
+size 2866

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:735711542ef4c1d22e35fa72e96c57e7fb024d20fab462b703898db6c7b3888c
+size 126

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:735711542ef4c1d22e35fa72e96c57e7fb024d20fab462b703898db6c7b3888c
+size 126

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:735711542ef4c1d22e35fa72e96c57e7fb024d20fab462b703898db6c7b3888c
+size 126

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:735711542ef4c1d22e35fa72e96c57e7fb024d20fab462b703898db6c7b3888c
+size 126

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:735711542ef4c1d22e35fa72e96c57e7fb024d20fab462b703898db6c7b3888c
+size 126

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:735711542ef4c1d22e35fa72e96c57e7fb024d20fab462b703898db6c7b3888c
+size 126

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:735711542ef4c1d22e35fa72e96c57e7fb024d20fab462b703898db6c7b3888c
+size 126

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:735711542ef4c1d22e35fa72e96c57e7fb024d20fab462b703898db6c7b3888c
+size 126

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Dest_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:735711542ef4c1d22e35fa72e96c57e7fb024d20fab462b703898db6c7b3888c
+size 126

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Add.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Add.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:189a6532b72752c8f2577532d8618cab0c36509540f67cb961864bc97cf4668d
+size 2801

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c37ab84e5cb1182c01ff08e7ca0880b86426e31d5cc7dd03be54427a12144dc
+size 2640

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19d1b711a96f155670df08f89437d99b11be2ef0096f783f18aeaf1683cdccbe
+size 1666

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:207e8145d3e1b03921d0ff24ec941985d63b91f30b27d1719367dd140f7d5fcd
+size 2408

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Darken.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Darken.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e6464b9c59032817e520d9ee4a95a76cf88711acd013d66c6e523e2833aecfb
+size 1669

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40362af24d60548ea62709573fa5a7aaa8ca6d5984694626be609a877f0889f4
+size 2858

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:189a6532b72752c8f2577532d8618cab0c36509540f67cb961864bc97cf4668d
+size 2801

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-HardLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-HardLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87fcc4da9c8cf636adb12e1297387043e5f0ab38299c2fa1f003a68d9703e376
+size 2015

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c37ab84e5cb1182c01ff08e7ca0880b86426e31d5cc7dd03be54427a12144dc
+size 2640

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Lighten.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Lighten.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:189a6532b72752c8f2577532d8618cab0c36509540f67cb961864bc97cf4668d
+size 2801

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f4f30c66e00517cdf214b08e4912664a266e1cd1141e029a316373443fc1f78
+size 2772

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Multiply.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Multiply.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:684cc1f63f44220fe7d4c4fe5a6c02148aa97e6a1e70150d26a7314fa21a0520
+size 1669

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Normal.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c089a73197b3e3bf8a10588d4641fab69d24b907a2663270e2a1517f0e061fa2
+size 2011

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Overlay.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Overlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccf03aa173ccc47ddb00d213eecfa82501c09832507122d718ce442384f938d0
+size 2259

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:207e8145d3e1b03921d0ff24ec941985d63b91f30b27d1719367dd140f7d5fcd
+size 2408

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Screen.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:189a6532b72752c8f2577532d8618cab0c36509540f67cb961864bc97cf4668d
+size 2801

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd71c3bfd23855f5a6bf5f7029f9cef58a4cc5b96b5328780e2931a80be8dddf
+size 2371

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Subtract.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Plus_blending-Subtract.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:577dcd57a52438b47e9ee968c04c2d95a84574610f31a7befea4e8faf07dee7c
+size 2689

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:007fdfe0c104900e564877a5dac40a8006dbe5cb7b51a5a2cb8f0526ec6c8a9c
+size 1556

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2df7b36320f4ba3d4f0c2456f2a3b969de849f8438da09749441cb0a3c2bbba0
+size 1491

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a2377b9cb0549bc0dc35b63af4f250da3e94054294e3d4c9ed151f317f70ce1
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:870ab486fceaa62b61080fef9ae617ba4fa6074b426cbef2e18db1ae0b63aaa4
+size 1565

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85e3a4be967f5cdffeb180bfefd2a8507667f4d55ec1480d71c331f1fca98394
+size 1560

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8c9d4f29abe39f2df8a31961a8bb1f3eb31dcbaa4d53af65d4d4c1ed46fab92
+size 1539

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a32aef2f6ada192645fe0955f54426532352b9b39aca852317682701be5c413
+size 1570

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:735711542ef4c1d22e35fa72e96c57e7fb024d20fab462b703898db6c7b3888c
+size 126

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcAtop_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9ce396f34807c54901b889fc51fda1ffa5a04dabde5195c4cc803475281f7e1
+size 1432

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f18d6b9d1e94a96a0bbf77e3d1c1c1b14f9d8682b24f7a76a3899ea8cddce3b
+size 1958

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f18d6b9d1e94a96a0bbf77e3d1c1c1b14f9d8682b24f7a76a3899ea8cddce3b
+size 1958

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f18d6b9d1e94a96a0bbf77e3d1c1c1b14f9d8682b24f7a76a3899ea8cddce3b
+size 1958

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f18d6b9d1e94a96a0bbf77e3d1c1c1b14f9d8682b24f7a76a3899ea8cddce3b
+size 1958

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f18d6b9d1e94a96a0bbf77e3d1c1c1b14f9d8682b24f7a76a3899ea8cddce3b
+size 1958

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f18d6b9d1e94a96a0bbf77e3d1c1c1b14f9d8682b24f7a76a3899ea8cddce3b
+size 1958

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f18d6b9d1e94a96a0bbf77e3d1c1c1b14f9d8682b24f7a76a3899ea8cddce3b
+size 1958

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f18d6b9d1e94a96a0bbf77e3d1c1c1b14f9d8682b24f7a76a3899ea8cddce3b
+size 1958

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcIn_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f18d6b9d1e94a96a0bbf77e3d1c1c1b14f9d8682b24f7a76a3899ea8cddce3b
+size 1958

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9b84a11e21f873194c37d908a6ab851c411a01dedef71cc3fdd3a6adb0c6a8
+size 2782

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9b84a11e21f873194c37d908a6ab851c411a01dedef71cc3fdd3a6adb0c6a8
+size 2782

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9b84a11e21f873194c37d908a6ab851c411a01dedef71cc3fdd3a6adb0c6a8
+size 2782

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9b84a11e21f873194c37d908a6ab851c411a01dedef71cc3fdd3a6adb0c6a8
+size 2782

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9b84a11e21f873194c37d908a6ab851c411a01dedef71cc3fdd3a6adb0c6a8
+size 2782

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9b84a11e21f873194c37d908a6ab851c411a01dedef71cc3fdd3a6adb0c6a8
+size 2782

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9b84a11e21f873194c37d908a6ab851c411a01dedef71cc3fdd3a6adb0c6a8
+size 2782

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9b84a11e21f873194c37d908a6ab851c411a01dedef71cc3fdd3a6adb0c6a8
+size 2782

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOut_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9b84a11e21f873194c37d908a6ab851c411a01dedef71cc3fdd3a6adb0c6a8
+size 2782

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3c8853a6c4aac6b87aaa99919a6d05c034286a2827bd75dcb9915e55415a9ec
+size 2671

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e32297dc90733aa6eb739e28a401de75881d726126cae5825cadd5b733b0ebb
+size 2675

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e6464b9c59032817e520d9ee4a95a76cf88711acd013d66c6e523e2833aecfb
+size 1669

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef3fac8bb5c05f161f3f736847cc648084bd5a4fa651db81bbb056b9b85eae49
+size 2636

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:859f3e49de6e7d613f4932e88ce0163f0771c932a4a6d91f7dde97528d5ed7ad
+size 2638

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:005fce330117637379b10273065ec53b17eb87bc283d9e3bfd6c788a575f5bc4
+size 2653

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff7c7dfa8f5819e5ac37277dbeae33729b3abe4437f2da88b1ffff505d5f6920
+size 2759

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2379c12cafd06ddca417cb2812ea4b71a597d897093e0877f7f258fd40aeba3
+size 1668

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-SrcOver_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa1643889844e90c457bc2691d140cd979a507c731c6783f3611a5696fed18b2
+size 2584

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a42ee71c40c516f6da8b0a08272066adb284302956bba8b02e119881d0b386
+size 3171

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a42ee71c40c516f6da8b0a08272066adb284302956bba8b02e119881d0b386
+size 3171

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a42ee71c40c516f6da8b0a08272066adb284302956bba8b02e119881d0b386
+size 3171

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a42ee71c40c516f6da8b0a08272066adb284302956bba8b02e119881d0b386
+size 3171

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a42ee71c40c516f6da8b0a08272066adb284302956bba8b02e119881d0b386
+size 3171

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a42ee71c40c516f6da8b0a08272066adb284302956bba8b02e119881d0b386
+size 3171

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a42ee71c40c516f6da8b0a08272066adb284302956bba8b02e119881d0b386
+size 3171

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a42ee71c40c516f6da8b0a08272066adb284302956bba8b02e119881d0b386
+size 3171

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Src_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99a42ee71c40c516f6da8b0a08272066adb284302956bba8b02e119881d0b386
+size 3171

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1056b33ad5e40aea6311def3c58d21a352941bce0decbe01ea61183c00bb14d7
+size 2664

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1056b33ad5e40aea6311def3c58d21a352941bce0decbe01ea61183c00bb14d7
+size 2664

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1056b33ad5e40aea6311def3c58d21a352941bce0decbe01ea61183c00bb14d7
+size 2664

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1056b33ad5e40aea6311def3c58d21a352941bce0decbe01ea61183c00bb14d7
+size 2664

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1056b33ad5e40aea6311def3c58d21a352941bce0decbe01ea61183c00bb14d7
+size 2664

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1056b33ad5e40aea6311def3c58d21a352941bce0decbe01ea61183c00bb14d7
+size 2664

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1056b33ad5e40aea6311def3c58d21a352941bce0decbe01ea61183c00bb14d7
+size 2664

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1056b33ad5e40aea6311def3c58d21a352941bce0decbe01ea61183c00bb14d7
+size 2664

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendSemiTransparentRedEllipse_composition-Xor_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1056b33ad5e40aea6311def3c58d21a352941bce0decbe01ea61183c00bb14d7
+size 2664

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Clear_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestAtop_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestIn_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOut_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559b4778de8a246e8b9152127b6a43ece3acb308bd975ac41826978322b2ab1
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24cb8c7bb6da36381a7b9e02114919f118235d278a09accc01fbac404a54c46c
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f23c0af3155c58de5594a423ac22f97288ad2d802c22f8ec89a9d32e9b363982
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dad21209bf248f696cd1e6df6e9d7c0f592613c70d856f62e6a9ce16ef7a4528
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559b4778de8a246e8b9152127b6a43ece3acb308bd975ac41826978322b2ab1
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620b61bd13fc6e6967a923287dd9236c1364861d15ed09a48a8cc1e3d99e4131
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:264320ec781ff7dda5707aa857025ee63fcd7716cb289e93a09cefe2aaec29fe
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-DestOver_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bea56d1fcfcbecd8362e996f0726b35a9eae0aa0ac403a05c6e7600e775f6938
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Dest_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Add.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Add.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e4b982f0e3825c7e74bf4a1c5b429c2bc8d4d0b51965faba3af248b80dd05a5
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:317f701db2a7db2c61ab1b3094de1a9ccec341367641388d740d4ca747401701
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Darken.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Darken.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d166c86a768bff0d93b077342b4e018e5477a9985d3cb26305b1e8c56e5d96b
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-HardLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-HardLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d930cd05dc2e190a3b949de6fe7a6a0e1363f6c7599cfafce73b5952cbb99da3
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e4b982f0e3825c7e74bf4a1c5b429c2bc8d4d0b51965faba3af248b80dd05a5
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Lighten.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Lighten.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559b4778de8a246e8b9152127b6a43ece3acb308bd975ac41826978322b2ab1
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Multiply.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Multiply.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f483dc4f64ce8b52b1d936ea0ac658d297c920d9d58cc7cf0eb038bcd42e2ea
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Normal.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Overlay.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Overlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Screen.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Subtract.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Plus_blending-Subtract.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b047a5333d017d4f872fc01474d6dd4e5be1ad4516a688bc519501cdfdf26cc5
+size 176

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:201cf99df1236e6f9b0f7929e9e6bac4e4262e5e31e68b77aac97a5e3a605d69
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efa692ee9f3b62532cfc2b4b0508e7a92c91691014bbd68a7b36f31eba98f790
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b8d84b52decc4037e6608ecdf7c5d8af7a9808431e0144d5384dec0a438fa7
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fc9e7917e148908dcc3315a23460049b0c2c3999d5feadfa6830a4acb21355f
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:571ae71474abad6c98fa5ea3a84d893938953b6c91739c9a420122c19861dc29
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:201cf99df1236e6f9b0f7929e9e6bac4e4262e5e31e68b77aac97a5e3a605d69
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:746dba78a01f7c633fb7c464789bcbf2bde3b6d5d835c3881cf182438ed49d6f
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcAtop_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:167aabfb98a42c5a41fae9f6cd31e18469b30d5474786aa5aa939b05900c9405
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcIn_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2cb9b57e84c44f15875c4ddcf3a068c5cc3ecb392b8ef905d918c01de581a24
+size 1295

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOut_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620b61bd13fc6e6967a923287dd9236c1364861d15ed09a48a8cc1e3d99e4131
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c08971dede0a316876b4b345c47e8c30ee73f8bbec7ec371febc74b168ea9bcd
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f23c0af3155c58de5594a423ac22f97288ad2d802c22f8ec89a9d32e9b363982
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dad21209bf248f696cd1e6df6e9d7c0f592613c70d856f62e6a9ce16ef7a4528
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620b61bd13fc6e6967a923287dd9236c1364861d15ed09a48a8cc1e3d99e4131
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559b4778de8a246e8b9152127b6a43ece3acb308bd975ac41826978322b2ab1
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b047a5333d017d4f872fc01474d6dd4e5be1ad4516a688bc519501cdfdf26cc5
+size 176

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-SrcOver_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa0784a437ee581ef643a7bc193bce6083b58893e6ddb9ef0fdd59b3d630b7bc
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Src_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:042446f2d4eb33c25256dac79081bc62e46e56ee2209daf8418550300d332684
+size 2099

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRectBlendTransparentEllipse_composition-Xor_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Clear_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559b4778de8a246e8b9152127b6a43ece3acb308bd975ac41826978322b2ab1
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24cb8c7bb6da36381a7b9e02114919f118235d278a09accc01fbac404a54c46c
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f23c0af3155c58de5594a423ac22f97288ad2d802c22f8ec89a9d32e9b363982
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dad21209bf248f696cd1e6df6e9d7c0f592613c70d856f62e6a9ce16ef7a4528
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559b4778de8a246e8b9152127b6a43ece3acb308bd975ac41826978322b2ab1
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620b61bd13fc6e6967a923287dd9236c1364861d15ed09a48a8cc1e3d99e4131
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:264320ec781ff7dda5707aa857025ee63fcd7716cb289e93a09cefe2aaec29fe
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestAtop_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bea56d1fcfcbecd8362e996f0726b35a9eae0aa0ac403a05c6e7600e775f6938
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestIn_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOut_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77ecd6cab29c9f68f9b1c495fe6465fc2e0f7c83b81f9d136feae3efd8c347c
+size 135

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559b4778de8a246e8b9152127b6a43ece3acb308bd975ac41826978322b2ab1
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24cb8c7bb6da36381a7b9e02114919f118235d278a09accc01fbac404a54c46c
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f23c0af3155c58de5594a423ac22f97288ad2d802c22f8ec89a9d32e9b363982
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dad21209bf248f696cd1e6df6e9d7c0f592613c70d856f62e6a9ce16ef7a4528
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559b4778de8a246e8b9152127b6a43ece3acb308bd975ac41826978322b2ab1
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620b61bd13fc6e6967a923287dd9236c1364861d15ed09a48a8cc1e3d99e4131
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:264320ec781ff7dda5707aa857025ee63fcd7716cb289e93a09cefe2aaec29fe
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-DestOver_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bea56d1fcfcbecd8362e996f0726b35a9eae0aa0ac403a05c6e7600e775f6938
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Dest_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Add.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Add.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e4b982f0e3825c7e74bf4a1c5b429c2bc8d4d0b51965faba3af248b80dd05a5
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:317f701db2a7db2c61ab1b3094de1a9ccec341367641388d740d4ca747401701
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Darken.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Darken.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d166c86a768bff0d93b077342b4e018e5477a9985d3cb26305b1e8c56e5d96b
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-HardLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-HardLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d930cd05dc2e190a3b949de6fe7a6a0e1363f6c7599cfafce73b5952cbb99da3
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e4b982f0e3825c7e74bf4a1c5b429c2bc8d4d0b51965faba3af248b80dd05a5
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Lighten.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Lighten.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559b4778de8a246e8b9152127b6a43ece3acb308bd975ac41826978322b2ab1
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Multiply.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Multiply.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f483dc4f64ce8b52b1d936ea0ac658d297c920d9d58cc7cf0eb038bcd42e2ea
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Normal.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Overlay.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Overlay.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Screen.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a33f56439bd22e8bac8a53f76a4f6589f1838f2a606fb74b53902fae64952f
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Subtract.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Plus_blending-Subtract.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b047a5333d017d4f872fc01474d6dd4e5be1ad4516a688bc519501cdfdf26cc5
+size 176

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:201cf99df1236e6f9b0f7929e9e6bac4e4262e5e31e68b77aac97a5e3a605d69
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efa692ee9f3b62532cfc2b4b0508e7a92c91691014bbd68a7b36f31eba98f790
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b8d84b52decc4037e6608ecdf7c5d8af7a9808431e0144d5384dec0a438fa7
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fc9e7917e148908dcc3315a23460049b0c2c3999d5feadfa6830a4acb21355f
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:571ae71474abad6c98fa5ea3a84d893938953b6c91739c9a420122c19861dc29
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:201cf99df1236e6f9b0f7929e9e6bac4e4262e5e31e68b77aac97a5e3a605d69
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:746dba78a01f7c633fb7c464789bcbf2bde3b6d5d835c3881cf182438ed49d6f
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d84ca3aad81a27c5d11fefda37153dbdbc11ff2d84e3c57711f21d5b22ecde8f
+size 127

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcAtop_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:167aabfb98a42c5a41fae9f6cd31e18469b30d5474786aa5aa939b05900c9405
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c441d50b1a5f7403cdf86563a38a9e380ae2cb2bb335880d341556f6ce1f3f63
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c441d50b1a5f7403cdf86563a38a9e380ae2cb2bb335880d341556f6ce1f3f63
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c441d50b1a5f7403cdf86563a38a9e380ae2cb2bb335880d341556f6ce1f3f63
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c441d50b1a5f7403cdf86563a38a9e380ae2cb2bb335880d341556f6ce1f3f63
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c441d50b1a5f7403cdf86563a38a9e380ae2cb2bb335880d341556f6ce1f3f63
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c441d50b1a5f7403cdf86563a38a9e380ae2cb2bb335880d341556f6ce1f3f63
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c441d50b1a5f7403cdf86563a38a9e380ae2cb2bb335880d341556f6ce1f3f63
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c441d50b1a5f7403cdf86563a38a9e380ae2cb2bb335880d341556f6ce1f3f63
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcIn_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c441d50b1a5f7403cdf86563a38a9e380ae2cb2bb335880d341556f6ce1f3f63
+size 147

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOut_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620b61bd13fc6e6967a923287dd9236c1364861d15ed09a48a8cc1e3d99e4131
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c08971dede0a316876b4b345c47e8c30ee73f8bbec7ec371febc74b168ea9bcd
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096b3e71a4447fd81557f74d78672d20c3790cba5613f5c2ce0eda7e212dc007
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f23c0af3155c58de5594a423ac22f97288ad2d802c22f8ec89a9d32e9b363982
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dad21209bf248f696cd1e6df6e9d7c0f592613c70d856f62e6a9ce16ef7a4528
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620b61bd13fc6e6967a923287dd9236c1364861d15ed09a48a8cc1e3d99e4131
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8559b4778de8a246e8b9152127b6a43ece3acb308bd975ac41826978322b2ab1
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b047a5333d017d4f872fc01474d6dd4e5be1ad4516a688bc519501cdfdf26cc5
+size 176

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-SrcOver_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa0784a437ee581ef643a7bc193bce6083b58893e6ddb9ef0fdd59b3d630b7bc
+size 183

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d166c86a768bff0d93b077342b4e018e5477a9985d3cb26305b1e8c56e5d96b
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d166c86a768bff0d93b077342b4e018e5477a9985d3cb26305b1e8c56e5d96b
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d166c86a768bff0d93b077342b4e018e5477a9985d3cb26305b1e8c56e5d96b
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d166c86a768bff0d93b077342b4e018e5477a9985d3cb26305b1e8c56e5d96b
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d166c86a768bff0d93b077342b4e018e5477a9985d3cb26305b1e8c56e5d96b
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d166c86a768bff0d93b077342b4e018e5477a9985d3cb26305b1e8c56e5d96b
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d166c86a768bff0d93b077342b4e018e5477a9985d3cb26305b1e8c56e5d96b
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d166c86a768bff0d93b077342b4e018e5477a9985d3cb26305b1e8c56e5d96b
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Src_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d166c86a768bff0d93b077342b4e018e5477a9985d3cb26305b1e8c56e5d96b
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Color.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-ColorBurn.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-ColorBurn.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-ColorDodge.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-ColorDodge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Difference.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Difference.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Exclusion.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Exclusion.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Hue.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Hue.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Luminosity.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Luminosity.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Saturation.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-Saturation.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-SoftLight.png
+++ b/tests/Images/ReferenceOutput/Drawing/ProcessWithDrawingCanvasTests/BlendingsDarkBlueRectBlendHotPinkRect_composition-Xor_blending-SoftLight.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6f01507f25ec90159d46faa286485950b3cd28aba1d20628390fef3d41539b9
+size 180

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/CanApplyPerspectiveTransform_StarWarsCrawl_WebGPU_NativeSurface.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/CanApplyPerspectiveTransform_StarWarsCrawl_WebGPU_NativeSurface.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e321ff9be5bf1cc3195a19d4df67eb8efcc5722dabb1e01b189e651688c6f2e0
-size 31623
+oid sha256:c184705fdbb798ab3ac2abf906d0f83be8f1d422ab2a94bcb308266854fe5ce8
+size 31898

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithEllipticGradientBrush_Reflect_MatchesDefaultOutput_Default.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithEllipticGradientBrush_Reflect_MatchesDefaultOutput_Default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f0302b87005c560b4c32b9705eac7865e08279d4f1586d6fcc208a986a9e02fc
-size 39586
+oid sha256:b9c2e0ed9e7e808b996d6d5f697a598de6bd2e79df260d88d6af624bcf1763e3
+size 39600

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithEllipticGradientBrush_Reflect_MatchesDefaultOutput_WebGPU_NativeSurface.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithEllipticGradientBrush_Reflect_MatchesDefaultOutput_WebGPU_NativeSurface.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38f3c4911b50fda06ca67633051bf7940a923f810b8f4bdfbaea55ca62cf75c3
-size 41712
+oid sha256:300dee22c69a4d2c30e8178c1a605d8606a04f36b856d6b2f2d662e6524c9fe9
+size 41373

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithLinearGradientBrush_ThreePoint_MatchesDefaultOutput_Default.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithLinearGradientBrush_ThreePoint_MatchesDefaultOutput_Default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f670831068c21e3151e5ff2f1a985bf9ec26445b74b815de5aba50316995d20a
-size 1370
+oid sha256:6aa68714c15b301d071f2620b077dc9a3b1b60c0a627c52894a25915eab042c7
+size 1448

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithLinearGradientBrush_ThreePoint_MatchesDefaultOutput_WebGPU_NativeSurface.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithLinearGradientBrush_ThreePoint_MatchesDefaultOutput_WebGPU_NativeSurface.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b7f8eddcaff139bb9fe86c5bafc18ff3ff8493a70267b10286491fba2470f70
-size 1367
+oid sha256:f554f942c2311470622b2e61468c01ccab936479bdcf218a9beba9471af62b5d
+size 1448

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithRadialGradientBrush_SingleCircle_MatchesDefaultOutput_Default.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithRadialGradientBrush_SingleCircle_MatchesDefaultOutput_Default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af2824eed2bb429f76270556cbb939a7f32558fa5eb9d7ada891ab3c888f45b2
-size 10237
+oid sha256:36eb200e0cfd9fd38fcdc02b0a5470ce7f8d98c2e17292158dbc785a8ef07dd2
+size 10117

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithRadialGradientBrush_SingleCircle_MatchesDefaultOutput_WebGPU_NativeSurface.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithRadialGradientBrush_SingleCircle_MatchesDefaultOutput_WebGPU_NativeSurface.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c1574eeedd282bd335abdb2f66376fb1be37184ba6ec80b93ae4b0e9cb5e90b
-size 10636
+oid sha256:73cfcc6c55010445c15c2083b4ef7d37203a60a9346b4cc9e1cdd78421523402
+size 10233

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithRadialGradientBrush_TwoCircle_MatchesDefaultOutput_Default.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithRadialGradientBrush_TwoCircle_MatchesDefaultOutput_Default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:109be2e6cf31cc56d54993f66cc88372d6c6faed807a93d38c67dd8d33c2c3d2
-size 10997
+oid sha256:49029a28f76d3f3cb01c1d8f5c5e70b43f70b048787d709e5693c3dc64db9d5b
+size 10990

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithRadialGradientBrush_TwoCircle_MatchesDefaultOutput_WebGPU_NativeSurface.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithRadialGradientBrush_TwoCircle_MatchesDefaultOutput_WebGPU_NativeSurface.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:32c8ef81ab1c429a96f3f676e1e984fd458925d82e73d17b339d04090fa60fe5
-size 9478
+oid sha256:a387d18bba0c69086b49b9a66f32ceb196cc8aa33b42cbb54b8a457ca457c2d2
+size 8797

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithSweepGradientBrush_MatchesDefaultOutput_WebGPU_NativeSurface.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithSweepGradientBrush_MatchesDefaultOutput_WebGPU_NativeSurface.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37859c68257acc9b1c8254fb0fefb01b574130790e55c0993149fd2f7dc00639
-size 15831
+oid sha256:1945a16c07d969162cd31dbf1f4aad0b756c20f91d42d858c9cc2ddc6ddec2b5
+size 15823

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithTranslucentGradientBrushes_MatchesDefaultOutput_Default.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithTranslucentGradientBrushes_MatchesDefaultOutput_Default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b8fdf795537a76e6c6d2cad30552507daff8576587305321f731ae74fd8fefd
-size 30601
+oid sha256:593a74588e149a40b38d6a1adf42510124b543eae48eca68c5f140b950f9079b
+size 23481

--- a/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithTranslucentGradientBrushes_MatchesDefaultOutput_WebGPU_NativeSurface.png
+++ b/tests/Images/ReferenceOutput/Drawing/WebGPUDrawingBackendTests/FillPath_WithTranslucentGradientBrushes_MatchesDefaultOutput_WebGPU_NativeSurface.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9bfc6d87b1de3f96243937c021d524d6dc4cb2397b30875aba3de7be75582619
-size 17374
+oid sha256:321d9b04c46e911bb43fa38526171bf79b5cb4403e3fa5f4d8553273ae50f9dc
+size 15256


### PR DESCRIPTION

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

Consumes the reworked Fonts renderer API and completes two WebGPU parity efforts.

## COLRv1 groups

`BaseGlyphBuilder` and `RichTextGlyphRenderer` implement `BeginGroup`/`EndGroup`; the canvas
lowers each group to one isolated layer whose modes apply when it ends. Caller opacity
applies once to the outermost group, never per leaf. The per-glyph clip bounds become a
single rectangle intersect on each operation's rasterizer interest; no polygon clipping is
involved anywhere.

## Layered glyph cache

A layered COLR cache hit now replays its stored operation sequence with zero renderer
callbacks: no outline decode and no path construction per draw. Replay tests assert
operation-for-operation equality and pixel-identical output.

## WebGPU blend parity

`blend.wgsl` ports ImageSharp's `AssociatedAlphaPorterDuffFunctions` and the straight-RGB
blend curves for every `PixelColorBlendingMode`. Stores quantize in-shader
(round-to-nearest-even binary16, exact unorm packing) so both backends store identical
pixels.

## CPU-exact brush colors

Solid colors and gradient ramp texels snap through `ToPixel<TPixel>` at flush, mirroring the
CPU's render-time brush creation: the retained scene streams specialize once per pixel
format and ride the ordinary uploads. Opaque fills are bit-exact against the CPU;
translucent fills sit within the wire format's binary16 rounding, documented at the patch
sites. Also fixes stale recolor payloads surviving a pixel-format switch.

<!-- Thanks for contributing to ImageSharp.Drawing! -->
