### PR TITLE
Fix rich text cloning and palette cache key

### DIFF
--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -44,8 +44,8 @@
     <InternalsVisibleTo Include="SixLabors.ImageSharp.Drawing.WebGPU" Key="$(SixLaborsPublicKey)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="3.0.1-alpha.0.17" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.1-alpha.0.23" />
+    <PackageReference Include="SixLabors.Fonts" Version="3.0.1-alpha.0.18" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.1-alpha.0.24" />
     <PackageReference Include="SixLabors.PolygonClipper" Version="1.0.1-alpha.0.6" />
   </ItemGroup>
 

--- a/src/ImageSharp.Drawing/Processing/RichTextGlyphRenderer.cs
+++ b/src/ImageSharp.Drawing/Processing/RichTextGlyphRenderer.cs
@@ -1219,6 +1219,14 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
         public Pen? PenReference { get; init; }
 
         /// <summary>
+        /// Gets the color palette selection the glyph's colors were resolved with, or
+        /// <see langword="null"/> when the glyph resolves no palette colors. The selection
+        /// changes the cached layer paints, so palette variants of one glyph must occupy
+        /// separate cache entries.
+        /// </summary>
+        public FontPalette? FontPalette { get; init; }
+
+        /// <summary>
         /// Determines whether two <see cref="CacheKey"/> instances are equal.
         /// </summary>
         /// <param name="left">The first key to compare.</param>
@@ -1269,7 +1277,8 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
                 TextAttributes = parameters.TextRun.TextAttributes,
                 TextDecorations = parameters.TextRun.TextDecorations,
                 Size = size,
-                PenReference = penReference
+                PenReference = penReference,
+                FontPalette = parameters.FontPalette
             };
 
         /// <inheritdoc/>
@@ -1291,7 +1300,8 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
             this.TextAttributes == other.TextAttributes &&
             this.TextDecorations == other.TextDecorations &&
             this.Size.Equals(other.Size) &&
-            ReferenceEquals(this.PenReference, other.PenReference);
+            ReferenceEquals(this.PenReference, other.PenReference) &&
+            Equals(this.FontPalette, other.FontPalette);
 
         /// <inheritdoc/>
         public override int GetHashCode()
@@ -1312,6 +1322,7 @@ internal sealed partial class RichTextGlyphRenderer : BaseGlyphBuilder
             hash.Add(this.TextDecorations);
             hash.Add(this.Size);
             hash.Add(this.PenReference is null ? 0 : RuntimeHelpers.GetHashCode(this.PenReference));
+            hash.Add(this.FontPalette);
             return hash.ToHashCode();
         }
     }

--- a/src/ImageSharp.Drawing/Processing/RichTextOptions.cs
+++ b/src/ImageSharp.Drawing/Processing/RichTextOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Six Labors Split License.
 
 using SixLabors.Fonts;
+using SixLabors.Fonts.Tables.AdvancedTypographic;
 
 namespace SixLabors.ImageSharp.Drawing.Processing;
 
@@ -27,12 +28,17 @@ public class RichTextOptions : TextOptions
         : base(options)
     {
         // Copy each run into a fresh instance so later mutation of the source runs
-        // cannot leak into this options instance (and vice versa).
+        // cannot leak into this options instance (and vice versa). Every property of
+        // RichTextRun and its TextRun base must appear here: a missing property
+        // silently resets to its default on the clone DrawText renders from.
         List<RichTextRun> runs = new(options.TextRuns.Count);
         foreach (RichTextRun run in options.TextRuns)
         {
             runs.Add(new RichTextRun()
             {
+                // Brushes, pens, fonts, and palettes copy by reference: each is immutable
+                // once constructed (FontPalette snapshots its overrides in its own
+                // constructor), so a shared reference cannot leak later mutation.
                 Brush = run.Brush,
                 Pen = run.Pen,
                 StrikeoutPen = run.StrikeoutPen,
@@ -41,8 +47,17 @@ public class RichTextOptions : TextOptions
                 Start = run.Start,
                 End = run.End,
                 Font = run.Font,
+                FontWeight = run.FontWeight,
+                Script = run.Script,
+                Culture = run.Culture,
+
+                // The feature tag list is the one caller-owned mutable collection on a
+                // run; the read-only interface is only a view, so isolation needs a copy.
+                FeatureTags = run.FeatureTags is null ? null : new List<Tag>(run.FeatureTags),
                 TextAttributes = run.TextAttributes,
                 TextDecorations = run.TextDecorations,
+                ColorFontSupport = run.ColorFontSupport,
+                FontPalette = run.FontPalette,
                 Placeholder = run.Placeholder
             });
         }

--- a/tests/ImageSharp.Drawing.Tests/Processing/DrawingCanvasTests.Text.cs
+++ b/tests/ImageSharp.Drawing.Tests/Processing/DrawingCanvasTests.Text.cs
@@ -107,6 +107,7 @@ public partial class DrawingCanvasTests
                         TextDecorations.None,
                         LayoutMode.HorizontalTopBottom,
                         ColorFontSupport.None,
+                        null,
                         out FontGlyphMetrics metrics))
                 {
                     continue;
@@ -160,6 +161,7 @@ public partial class DrawingCanvasTests
                         TextDecorations.None,
                         LayoutMode.HorizontalTopBottom,
                         ColorFontSupport.None,
+                        null,
                         out FontGlyphMetrics metrics))
                 {
                     continue;
@@ -306,6 +308,7 @@ public partial class DrawingCanvasTests
                         TextDecorations.None,
                         LayoutMode.HorizontalTopBottom,
                         ColorFontSupport.None,
+                        null,
                         out FontGlyphMetrics metrics))
                 {
                     continue;
@@ -820,6 +823,7 @@ public partial class DrawingCanvasTests
                     TextDecorations.None,
                     LayoutMode.HorizontalTopBottom,
                     ColorFontSupport.None,
+                    null,
                     out FontGlyphMetrics metrics))
             {
                 continue;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds missing `RichTextRun` fields to the `RichTextOptions` copy constructor, including feature tags, shaping metadata, color font settings, and font palette, so cloned options preserve run behavior correctly. It also includes `FontPalette` in glyph cache keys to prevent cache collisions between palette variants, and updates SixLabors.Fonts/ImageSharp package versions.

<!-- Thanks for contributing to ImageSharp.Drawing! -->
