### PR TITLE
Update Six Labors Refs

### DIFF
--- a/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
+++ b/src/ImageSharp.Drawing/ImageSharp.Drawing.csproj
@@ -44,8 +44,8 @@
     <InternalsVisibleTo Include="SixLabors.ImageSharp.Drawing.WebGPU" Key="$(SixLaborsPublicKey)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="3.0.1-alpha.0.19" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.1-alpha.0.24" />
+    <PackageReference Include="SixLabors.Fonts" Version="3.1.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.1.0" />
     <PackageReference Include="SixLabors.PolygonClipper" Version="1.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp.Drawing/pulls) open
- [x] I have verified that I am following matches the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This pull request updates third-party dependencies in the `ImageSharp.Drawing` project to use newer stable versions.

Dependency updates:

* Updated `SixLabors.Fonts` package from version `3.0.1-alpha.0.19` to `3.1.0`, moving from an alpha to a stable release.
* Updated `SixLabors.ImageSharp` package from version `4.0.1-alpha.0.24` to `4.1.0`, moving from an alpha to a stable release.
<!-- Thanks for contributing to ImageSharp.Drawing! -->
